### PR TITLE
expand footer & BOSC pages

### DIFF
--- a/content/page/bosc-2025.md
+++ b/content/page/bosc-2025.md
@@ -20,7 +20,13 @@ The second day of BOSC will be a joint session with the newly-renamed
 Last year's conference, [BOSC 2024](events/bosc-2024), took place July 15-16, 2024 as part of [ISMB 2024](https://www.iscb.org/ismb2024/), in Montréal, Canada and online.
 Videos of the talks from BOSC 2024 are available on our [YouTube channel](https://www.youtube.com/@OBFBOSC/). Our report about BOSC 2024 is [published in F1000Research](https://f1000research.com/articles/13-1100).
 
-### BOSC 2025 Key Dates
+
+
+<div class="well">
+
+## BOSC 2025 Key Dates
+
+
 
 {{< columns >}}
 - January 20, 2025: Call for abstracts opens
@@ -35,6 +41,9 @@ Videos of the talks from BOSC 2024 are available on our [YouTube channel](https:
 
 ![Larry Hunter and Melanie Courtot at BOSC 2024](/wp-content/uploads/2024/08/Larry-and-Melanie-in-BOSC-audience-1.jpeg)
 {{< endcolumns >}}
+
+
+</div>
 
 
 ### Topics
@@ -57,7 +66,7 @@ Videos of the talks from BOSC 2024 are available on our [YouTube channel](https:
 - ...and more!
 {{< endcolumns >}}
 
-**Registration and Financial Assistance**
+### Registration and Financial Assistance
 
 To participate in BOSC 2025 or the ISMB CollaborationFest, you will
 need to register for ISMB/ECCB 2025. Those who
@@ -107,13 +116,27 @@ Seqera makes complex data analysis accessible at any scale
 
 [![CZI](/wp-content/uploads/2021/06/CZI_Logotype_RGB.jpg)](https://chanzuckerberg.com/science)
 
+
+{{< columns >}}
+
 **2024 Gold Sponsor:**
 
 [![NIH Data Science](/wp-content/uploads/2024/04/NIH-ODSS_Horizontal_1Color-653.jpg)](https://datascience.nih.gov/)
 
+{{< column >}}
 **2024 Silver Sponsor:**
 
+{{< columns >}}
+
 [![GigaScience](/wp-content/uploads/2019/05/Gigascience.png)](https://academic.oup.com/gigascience)
+
+{{< column >}}
+
+{{< endcolumns >}}
+
+{{< endcolumns >}}
+
+<div class="well">
 
 ### About BOSC
 
@@ -129,8 +152,9 @@ opportunity for anyone interested in open science, biology and
 programming to meet, talk and work collaboratively. In 2025,
 CollaborationFest will be part of ISMB/ECCB!
 
-[More about BOSC...](/events/bosc/about/)
+<a href="/events/bosc/about" class="btn btn-lg btn-primary">More about BOSC</a>
 
+</div>
 
 #### Code of Conduct
 

--- a/content/page/submit-to-bosc-2025.md
+++ b/content/page/submit-to-bosc-2025.md
@@ -13,9 +13,8 @@ bosc: yes
 # BOSC 2025 Abstract Submission
 
 
-
+{{< columns >}}
 BOSC 2025, the 26th annual Bioinformatics Open Source Conference, will take place July 21-22, 2025 in Liverpool, UK (as part of [ISMB/ECCB 2025](https://www.iscb.org/ismbeccb2025/home)). BOSC covers all aspects of open source bioinformatics and open science.
-
 
 
 Abstract submission is now open! We welcome submission of your 1-2 page abstract for consideration as a talk or poster.
@@ -24,9 +23,15 @@ The second day of BOSC will be a joint session with the newly renamed Bio-Ontolo
 
 Please see below for submission instructions.
 
+{{< column >}}
+
 ![Poster from BOSC 2022](/wp-content/uploads/2022/11/Festus-Nyastimi-poster-BOSC2022.png)
 
 ![Photo of some speakers at BOSC 2024](/wp-content/uploads/2024/08/speakers-in-Standards-and-frameworks-for-open-science-session-1.jpeg)
+
+{{< endcolumns >}}
+
+<div class='well'>
 
 ### Key Dates
 
@@ -38,6 +43,8 @@ Please see below for submission instructions.
 - **July 21-22, 2025:** **BOSC 2025** (part of ISMB/ECCB 2025)
 - July 23-24: ISMB CollaborationFest
 
+</div>
+
 # ISMB rules
 
 **In-person presentation**: "For a variety of reasons, ISCB strongly prefers that scientific research accepted for oral presentation be presented in-person at the conference venue. ISCB will grant remote presentation options for reasons associated with maternity/paternity leave, care for a family member, personal/medical disability, sickness, financial hardship, or potential visa problems."
@@ -46,39 +53,40 @@ Please see below for submission instructions.
 
 # Submission guidelines
 
+{{< columns >}}
+
 ### What to submit
 
-Please describe how your work fits into the open source bioinformatics / open science ecosystem. We like to see examples of biological applications of your work, and a summary of the current and/or projected community aspect of your project.
+- Please describe how your work fits into the open source bioinformatics / open science ecosystem. We like to see examples of biological applications of your work, and a summary of the current and/or projected community aspect of your project.
+- A 250-word short abstract (text only) is required for ALL submissions (talk and/or poster).
+- If you want to be considered for a talk, you also MUST attach a 1-2 page "long abstract" as a PDF. Figures welcome as long as the total length is 2 pages or less.
+- Your abstract PDF should include the title, author name(s), open source license, and code or project URL (even though this information is also requested on the submission form).
 
-A 250-word short abstract (text only) is required for ALL submissions (talk and/or poster).
-
-If you want to be considered for a talk, you also MUST attach a 1-2 page "long abstract" as a PDF. Figures welcome as long as the total length is 2 pages or less.
-
-Your abstract PDF should include the title, author name(s), open source license, and code or project URL (even though this information is also requested on the submission form).
+{{< column >}}
 
 ### Requirements
 
 To be accepted (even for poster presentation), abstracts submitted to BOSC must be:
 
-**Relevant**: Your abstract must describe how your work relates to some aspect of open source software, open science or open data applied to biology or biomedical science.
+- **Relevant**: Your abstract must describe how your work relates to some aspect of open source software, open science or open data applied to biology or biomedical science.
+- **Available**: Your code / data / materials must be available at the URL you list **at the time of review**.
+- **Open Content**: Work discussed in BOSC presentations must be open source / open content, with a recognized license (which must be included in the repository). For abstracts about non-software products or projects (e.g., educational materials), these should also be made freely available with an appropriate open license. See below for more information.
+- **Updated**: If you presented this work at a previous BOSC in any form (talk, demo, poster), your abstract must describe progress since the last BOSC presentation.
 
-**Available**: Your code / data / materials must be available at the URL you list **at the time of review**.
-
-**Open Content**: Work discussed in BOSC presentations must be open source / open content, with a recognized license (which must be included in the repository). For abstracts about non-software products or projects (e.g., educational materials), these should also be made freely available with an appropriate open license. See below for more information.
-
-**Updated**: If you presented this work at a previous BOSC in any form (talk, demo, poster), your abstract must describe progress since the last BOSC presentation.
+{{< endcolumns >}}
 
 ### Additional criteria
 
-In addition to the requirements listed at left, we consider the following when selecting abstracts for short or long talks.
+In addition to the requirements listed above, we consider the following when selecting abstracts for short or long talks.
 
-**Community impact**: Please describe how your work fits into the open source bioinformatics / open science ecosystem. A summary of the current and/or projected community aspect of your project is very helpful.
+- **Community impact**: Please describe how your work fits into the open source bioinformatics / open science ecosystem. A summary of the current and/or projected community aspect of your project is very helpful.
+- **Novelty**: Innovative approaches are interesting to hear about, but it’s fine to build on existing technology! If you can compare your approach with existing approaches, that’s a plus.
+- **Examples**: We like abstracts with examples of how your approach works (e.g. a figure showing the output of a visualization tool, an example of software input/output, or benchmarks on relevant data).
+- **Runnable**: Although we are happy to consider abstracts that describe early-phase projects, our reviewers are likely to look at your code and try to run it. Reviewers like projects that they are able to download and run, and that are well-documented and easy to use.
 
-**Novelty**: Innovative approaches are interesting to hear about, but it’s fine to build on existing technology! If you can compare your approach with existing approaches, that’s a plus.
+<div class="well">
 
-**Examples**: We like abstracts with examples of how your approach works (e.g. a figure showing the output of a visualization tool, an example of software input/output, or benchmarks on relevant data).
-
-**Runnable**: Although we are happy to consider abstracts that describe early-phase projects, our reviewers are likely to look at your code and try to run it. Reviewers like projects that they are able to download and run, and that are well-documented and easy to use.
+{{< columns >}}
 
 ### How to Submit
 
@@ -92,11 +100,17 @@ In addition to the requirements listed at left, we consider the following when s
 - Abstract template (optional): [bosc-abstract-template](/wp-content/uploads/2022/04/bosc2022-abstract-template.docx) (MS Word)
 - You don't need to register before you submit your abstract, but to present your talk or poster you will need to register for ISMB.
 
+{{< column >}}
+
 ![](/wp-content/uploads/2022/01/Screen-Shot-2022-01-19-at-3.59.31-PM.png)
 
 Watch a video of [BOSC organizing committee member Jason Williams discussing how to write a great BOSC abstract](https://youtu.be/DwJRrh1Tpew)!  
 
-[Submit Abstract](https://easychair.org/conferences/?conf=ismbeccb2025)
+{{< endcolumns >}}
+
+<a href="https://easychair.org/conferences/?conf=ismbeccb2025" class="btn btn-lg btn-primary">Submit Abstract</a>
+
+</div>
 
 # BOSC Open Content Requirement
 
@@ -127,4 +141,5 @@ Abstracts submitted to BOSC are reviewed by at least three reviewers. Our review
 
 We realize that the cost of ISMB may be prohibitive for some. If you are submitting an abstract to BOSC and would have difficulty covering the cost of registration, you can request registration fee assistance. To make it easy, this request can be made right on the abstract submission form. (Only the conference chairs will see these fee assistance requests -- the abstract reviewers will not.) Last year, thanks to help from our [sponsors](/events/bosc-2024-sponsors/), we were able to grant free registration to 15 participants.
 
-[Submit Abstract]( https://easychair.org/conferences/?conf=ismbeccb2025)
+<a href="https://easychair.org/conferences/?conf=ismbeccb2025" class="btn btn-lg btn-primary">Submit Abstract</a>
+

--- a/data/beautifulhugo/social.toml
+++ b/data/beautifulhugo/social.toml
@@ -1,0 +1,228 @@
+[[social_icons]]
+id = "email"
+url = "mailto:%s"
+title = "Email me"
+icon = "fas fa-envelope"
+
+[[social_icons]]
+id = "facebook"
+url = "https://www.facebook.com/%s"
+title = "Facebook"
+icon = "fab fa-facebook"
+
+[[social_icons]]
+id = "github"
+url = "https://github.com/%s"
+title = "GitHub"
+icon = "fab fa-github"
+
+[[social_icons]]
+id = "gitlab"
+url = "https://gitlab.com/%s"
+title = "GitLab"
+icon = "fab fa-gitlab"
+
+[[social_icons]]
+id = "bitbucket"
+url = "https://bitbucket.org/%s"
+title = "Bitbucket"
+icon = "fab fa-bitbucket"
+
+[[social_icons]]
+id = "twitter"
+url = "https://twitter.com/%s"
+title = "Twitter"
+icon = "fab fa-x-twitter"
+
+[[social_icons]]
+id = "slack"
+url = "%s"
+title = "Slack"
+icon = "fab fa-slack"
+
+[[social_icons]]
+id = "reddit"
+url = "https://reddit.com/u/%s"
+title = "Reddit"
+icon = "fab fa-reddit-alien"
+
+[[social_icons]]
+id = "linkedin"
+url = "%s"
+title = "LinkedIn"
+icon = "fab fa-linkedin"
+
+[[social_icons]]
+id = "xing"
+url = "https://www.xing.com/profile/%s"
+title = "Xing"
+icon = "fab fa-xing"
+
+[[social_icons]]
+id = "stackoverflow"
+url = "https://stackoverflow.com/%s"
+title = "StackOverflow"
+icon = "fab fa-stack-overflow"
+
+[[social_icons]]
+id = "snapchat"
+url = "https://www.snapchat.com/add/%s"
+title = "Snapchat"
+icon = "fab fa-snapchat-ghost"
+
+[[social_icons]]
+id = "instagram"
+url = "https://www.instagram.com/%s"
+title = "Instagram"
+icon = "fab fa-instagram"
+
+[[social_icons]]
+id = "youtube"
+url = "https://www.youtube.com/%s"
+title = "Youtube"
+icon = "fab fa-youtube"
+
+[[social_icons]]
+id = "soundcloud"
+url = "https://soundcloud.com/%s"
+title = "SoundCloud"
+icon = "fab fa-soundcloud"
+
+[[social_icons]]
+id = "spotify"
+url = "https://open.spotify.com/user/%s"
+title = "Spotify"
+icon = "fab fa-spotify"
+
+[[social_icons]]
+id = "bandcamp"
+url = "https://%s.bandcamp.com/"
+title = "Bandcamp"
+icon = "fab fa-bandcamp"
+
+[[social_icons]]
+id = "itchio"
+url = "https://itch.io/profile/%s"
+title = "Itch.io"
+icon = "fas fa-gamepad"
+
+[[social_icons]]
+id = "keybase"
+url = "https://keybase.io/%s"
+title = "Keybase"
+icon = "fab fa-keybase"
+
+[[social_icons]]
+id = "vk"
+url = "https://vk.com/%s"
+title = "VK"
+icon = "fab fa-vk"
+
+[[social_icons]]
+id = "paypal"
+url = "https://paypal.me/%s"
+title = "PayPal"
+icon = "fab fa-paypal"
+
+[[social_icons]]
+id = "telegram"
+url = "https://telegram.me/%s"
+title = "Telegram"
+icon = "fab fa-telegram"
+
+[[social_icons]]
+id = "500px"
+url = "https://500px.com/%s"
+title = "500px"
+icon = "fab fa-500px"
+
+[[social_icons]]
+id = "codepen"
+url = "https://codepen.io/%s"
+title = "CodePen"
+icon = "fab fa-codepen"
+
+[[social_icons]]
+id = "kaggle"
+url = "https://www.kaggle.com/%s"
+title = "kaggle"
+icon = "fab fa-kaggle"
+
+[[social_icons]]
+id = "mastodon"
+url = "https://%s"
+title = "Mastodon"
+icon = "fab fa-mastodon"
+rel = "me"
+
+[[social_icons]]
+id = "weibo"
+url = "https://weibo.com/%s"
+title = "Weibo"
+icon = "fab fa-weibo"
+
+[[social_icons]]
+id = "medium"
+url = "https://medium.com/@%s"
+title = "Medium"
+icon = "fab fa-medium"
+
+[[social_icons]]
+id = "discord"
+url = "https://discord.gg/%s"
+title = "Discord"
+icon = "fab fa-discord"
+
+[[social_icons]]
+id = "strava"
+url = "https://www.strava.com/athletes/%s"
+title = "Strava"
+icon = "fab fa-strava"
+
+[[social_icons]]
+id = "steam"
+url = "https://steamcommunity.com/id/%s"
+title = "Steam"
+icon = "fab fa-steam"
+
+[[social_icons]]
+id = "quora"
+url = "https://www.quora.com/profile/%s"
+title = "Quora"
+icon = "fab fa-quora"
+
+[[social_icons]]
+id = "amazonwishlist"
+url = "https://amzn.com/w/%s"
+title = "Amazon Wishlist"
+icon = "fab fa-amazon"
+
+[[social_icons]]
+id = "slideshare"
+url = "https://www.slideshare.net/%s"
+title = "Slideshare"
+icon = "fab fa-slideshare"
+
+[[social_icons]]
+id = "angellist"
+url = "https://www.angel.co/p/%s"
+title = "AngelList"
+icon = "fab fa-angellist"
+
+[[social_icons]]
+id = "about"
+url = "%s"
+title = "About"
+icon = "fas fa-at"
+
+[[social_icons]]
+id = "lastfm"
+url = "https://www.last.fm/user/%s"
+title = "Last.fm"
+icon = "fab fa-lastfm"
+
+[[social_icons]]
+id = "bluesky"
+url = "https://bsky.app/profile/%s"
+title = "Bluesky"
+icon = "fab fa-bluesky"

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -18,6 +18,7 @@ params:
   showCodeCopyButtons: true
   comments: true
   hideFooter: true
+  rss: true
   assets:
     favicon: /favicon.ico
     disableHLJS: true
@@ -29,6 +30,9 @@ params:
     email: 'board@open-bio.org'
     github: 'obf'
     mastodon: 'genomic.social/@openbio'
+    slack: 'https://join.slack.com/t/open-bio/shared_invite/zt-1pnswao9y-8igcckVxBXhQHCMweHt_NA'
+    bluesky: '@openbio.bsky.social'
+    linkedin: 'https://www.linkedin.com/groups/9539620/'
 markup:
   highlight:
     codeFences: true


### PR DESCRIPTION
I've expanded some of the wishlist things: 

- the footer now has all the socials etc we had before 
- (some of) the BOSC pages now have a "well" applied (`<div class="well"> content </div>`)
- The submit-links are now (visually) buttons
- I've formatted the sponsor logos a bit, @nlharris is this what you had in mind? (Done by nesting columns)

See screenshots below as well :)  


![image](https://github.com/user-attachments/assets/ea59e5ca-5e3a-44bf-b396-36f343fb17a3)


![image](https://github.com/user-attachments/assets/9184aae4-7132-433f-89c0-35b67a5eefac)

![image](https://github.com/user-attachments/assets/5e1f8f5d-4fd4-4439-ac9d-11bf08037de5)

![image](https://github.com/user-attachments/assets/b9241b51-4ee8-474d-9b39-05b0932eca7d)
