### PR TITLE
fix a few mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ fork" button.
 git checkout main
 git pull
 ```
-9. Edit your local copy as desired. Then do the steps in #4 (with a new branch name) to commit your latest changes.
+9. Edit your local copy as desired. Then do the steps in #4 (with a NEW branch name) to commit your latest changes.
 
 
 ### Using hugo

--- a/content/page/bosc-2025.md
+++ b/content/page/bosc-2025.md
@@ -21,7 +21,7 @@ bosc: yes
 The second day of BOSC 2025 will feature a joint session with the newly-renamed
 [Bio-Ontologies and Knowledge Representation](https://www.bio-ontologies.org.uk/2025-meeting), and will feature a joint keynote and talks on some of our favorite topics, including open data and reusable and reproducible science.
 
-Last year's conference, [BOSC 2024](events/bosc-2024), took place July 15-16, 2024 as part of [ISMB 2024](https://www.iscb.org/ismb2024/), in Montréal, Canada and online.
+Last year's conference, [BOSC 2024](/events/bosc-2024), took place July 15-16, 2024 as part of [ISMB 2024](https://www.iscb.org/ismb2024/), in Montréal, Canada and online.
 Videos of the talks from BOSC 2024 are available on our [YouTube channel](https://www.youtube.com/@OBFBOSC/). Our report about BOSC 2024 was [published in F1000Research](https://f1000research.com/articles/13-1100).
 
 <br/>

--- a/content/page/sponsors-3.md
+++ b/content/page/sponsors-3.md
@@ -23,7 +23,7 @@ Sponsorships from companies and non-profit organizations help to defray some of 
 
 {{< column >}}
 
-![Nomi by BOSC 2024 poster](/wp-content/uploads/2025/01/nomi-by-bosc2024-poster.jpg)
+![Nomi by BOSC 2024 poster](/wp-content/uploads/2025/01/nomi-by-BOSC2024-poster.jpg)
 
 {{< endcolumns >}}
 


### PR DESCRIPTION
a picture on the sponsors page showed up in my localhost but not when pushed to obf.github.io.

i am hoping this change fixes that:
< ![Nomi by BOSC 2024 poster](/wp-content/uploads/2025/01/nomi-by-bosc2024-poster.jpg)
> ![Nomi by BOSC 2024 poster](/wp-content/uploads/2025/01/nomi-by-BOSC2024-poster.jpg)

uh oh, there's still a lowercase n. but i'm not sure that's a problem.
