### PR TITLE
not just capital N; also events/sponsors -> events/bosc/sponsors

### DIFF
--- a/content/page/sponsors-3.md
+++ b/content/page/sponsors-3.md
@@ -6,7 +6,7 @@ cover:
 date: "2023-03-27T19:05:24+00:00"
 guid: https://www.open-bio.org/?page_id=6961
 title: Sponsors
-url: /events/sponsors/
+url: /events/bosc/sponsors/
 bosc: yes
 ---
 # Sponsoring BOSC 2025
@@ -23,7 +23,7 @@ Sponsorships from companies and non-profit organizations help to defray some of 
 
 {{< column >}}
 
-![Nomi by BOSC 2024 poster](/wp-content/uploads/2025/01/nomi-by-BOSC2024-poster.jpg)
+![Nomi by BOSC 2024 poster](/wp-content/uploads/2025/01/Nomi-by-BOSC2024-poster.jpg)
 
 {{< endcolumns >}}
 

--- a/content/page/submit-to-bosc-2025.md
+++ b/content/page/submit-to-bosc-2025.md
@@ -149,7 +149,7 @@ Abstracts submitted to BOSC are reviewed by at least three reviewers. Our review
 
 {{< columns >}}
 
-We realize that the cost of ISMB may be prohibitive for some. If you are submitting an abstract to BOSC and would have difficulty covering the cost of registration, you can request registration fee assistance. To make it easy, this request can be made right on the abstract submission form. (Only the conference chairs will see these fee assistance requests -- the abstract reviewers will not.) Last year, thanks to help from our [sponsors](/events/bosc-2024-sponsors/), we were able to grant free registration to 15 participants.
+We realize that the cost of ISMB may be prohibitive for some. If you are submitting an abstract to BOSC and would have difficulty covering the cost of registration, you can request registration fee assistance. To make it easy, this request can be made right on the abstract submission form. (Only the conference chairs will see these fee assistance requests -- the abstract reviewers will not.) Last year, thanks to help from our [sponsors](/events/bosc/sponsors/), we were able to grant free registration to 15 participants.
 
 {{< column >}}
 ![Farah Khan and her poster](/wp-content/uploads/2019/02/farah-presentation.jpg)

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -86,7 +86,7 @@ menu:
     - name: 'Sponsors'
       weight: 4
       parent: 'bosc'
-      url: 'events/sponsors/'
+      url: 'events/bosc/sponsors/'
     - name: "CoFest (2024)"
       weight: 5
       parent: 'bosc'


### PR DESCRIPTION
On localhost, the capitalization in image names (/wp-content/uploads/2025/01/nomi-by-BOSC2024-poster.jpg) didn't matter, but on obf.github.io, it does!

changed path events/sponsors -> events/bosc/sponsors