### PR TITLE
Formatting the EDI page

### DIFF
--- a/content/page/how-bosc-supports-diversity-inclusion-and-accessibility.md
+++ b/content/page/how-bosc-supports-diversity-inclusion-and-accessibility.md
@@ -5,71 +5,151 @@ cover:
   image: /wp-content/uploads/2023/08/2023-panel-1-1.png
 date: "2023-08-19T17:48:09+00:00"
 guid: https://www.open-bio.org/?page_id=7251
-title: How OBF supports diversity, inclusion and accessibility
+title: How we support diversity, inclusion and accessibility
 url: /obf-dei/
 aliases: 
   - /bosc-dei/
 ---
 Diversity, inclusion and accessibility (also known as Diversity, Equity and Inclusion, DEI) are a major part of OBF and [BOSC's](/?obf-events=bosc-2023) mission and core values.
 
-Below are some of the ways we have worked to promote DEI at OBF, BOSC as well as at ISMB (our host conference) and in the broader open bioinformatics community.
+Below are some of the ways we have worked to promote DEI at OBF, BOSC, ISMB (the host conference for BOSC) and in the broader open bioinformatics community.
 
-![](/wp-content/uploads/2023/03/Ruth-Nanjala-cropped-OBF-event-fellowship-winner-260x300.jpg)
+{{< columns >}}
 
-\- The Open Bioinformatics Foundation, funds the [OBF event fellowships](/event-awards/), which aim to increase diversity at events (including, but not limited to, BOSC) that promote open science as a research practice. These fellowships fund participants whose attendance will contribute to increase the diversity of such events (e.g. underrepresented demographic groups, ethnic origins, career stages, and disabilities).
+![a person standing next to their conference poster](/wp-content/uploads/2023/03/Ruth-Nanjala-cropped-OBF-event-fellowship-winner-260x300.jpg)
 
-![](/wp-content/uploads/2023/08/Nomi-Deepak-Vasundra-1-1024x782.jpeg)![](/wp-content/uploads/2022/12/Farica-Zhuang-and-Matthew-Gazzara-1-284x300.jpeg)
 
-\- Authors who submit their work to BOSC can request ISMB registration fee support on the submission form (these requests are not seen by reviewers). This initiative is funded by [sponsorships](/events/sponsors/).
+{{< column >}}
 
-Since we introduced this option three years ago, we've been able to offer free registration to dozens of people, most of whom are from groups underrepresented at ISMB/BOSC. In 2022, 19 people (of whom 18 were from groups that are underrepresented in our community) were granted free registration thanks to a combination of these registration fee waivers and OBF event fellowships. In 2023, 15 people (13 from underrepresented groups) were given free registration to ISMB/BOSC. In 2024, 14 people (13 from underrepresented groups) received free registration.
+The Open Bioinformatics Foundation, **funds the [OBF event fellowships](/event-awards/), which aim to increase diversity at events (including, but not limited to, BOSC) that promote open science as a research practice**. These fellowships fund participants whose attendance will contribute to increase the diversity of such events (e.g. underrepresented demographic groups, ethnic origins, career stages, and disabilities).
 
-![](/wp-content/uploads/2023/08/BOSC2023-crowded-room-Jason-standing-1-1024x372.png)![Jason Williams delivered one of the keynote talks at BOSC 2022](/wp-content/uploads/2022/08/image5-e1675318372322-251x300.jpg)
+{{< endcolumns >}}
 
-\- To help everyone feel welcome at BOSC, we introduced a code of conduct in 2015, and successfully lobbied our host conference ISMB to adopt one as well. OBF adopted a [code of conduct](https://github.com/OBF/obf-docs/tree/master/code-of-conduct) in 2022.
+{{< columns >}}
 
-\- We strive to choose keynote speakers who represent a diversity of backgrounds and ideas. To make our selection process fair and transparent, we developed an [invited speaker rubric](https://github.com/OBF/bosc_materials/blob/master/invited-speaker-process.md) and an opportunity for [community members to nominate potential keynote speakers and comment on nominees](/2023/02/02/nominate-keynote-speaker-for-bosc-2023/).
+**Authors who submit their work to BOSC can request ISMB registration fee support** on the submission form (these requests are not seen by reviewers). This initiative is funded by [sponsorships](/events/sponsors/).
+
+Since we introduced this option three years ago, we've been able to offer free registration to dozens of people, most of whom are from groups underrepresented at ISMB/BOSC:
+
+* In 2022, 19 people (of whom 18 were from groups that are underrepresented in our community) were granted free registration thanks to a combination of these registration fee waivers and OBF event fellowships. 
+* In 2023, 15 people (13 from underrepresented groups) were given free registration to ISMB/BOSC. 
+* In 2024, 14 people (13 from underrepresented groups) received free registration.
+
+
+{{< column >}}
+
+![three people standing in a conference room](/wp-content/uploads/2023/08/Nomi-Deepak-Vasundra-1-1024x782.jpeg)
+
+![a person standing at a podium presenting](/wp-content/uploads/2022/12/Farica-Zhuang-and-Matthew-Gazzara-1-284x300.jpeg)
+
+
+{{< endcolumns >}}
+
+{{< columns >}}
+
+![A crowded conference room](/wp-content/uploads/2023/08/BOSC2023-crowded-room-Jason-standing-1-1024x372.png)
+
+
+{{< column >}}
+
+To help everyone feel welcome at BOSC, we **introduced a code of conduct in 2015**, and successfully lobbied our host conference ISMB to adopt one as well. OBF adopted a [code of conduct](https://github.com/OBF/obf-docs/tree/master/code-of-conduct) in 2022.
+
+{{< endcolumns >}}
+
+{{< columns >}}
+We strive to **choose keynote speakers who represent a diversity of backgrounds and ideas**. To make our selection process fair and transparent, we developed an [invited speaker rubric](https://github.com/OBF/bosc_materials/blob/master/invited-speaker-process.md) and an opportunity for [community members to nominate potential keynote speakers and comment on nominees](/2023/02/02/nominate-keynote-speaker-for-bosc-2023/).
+
+Our 2023 keynote speakers both discussed topics related to inclusion and equity. The first [BOSC 2023 keynote](/events/bosc-2023/bosc-2023-keynotes/) was delivered by Sara El-Gebali, who spoke inspiringly about “A New Odyssey: Pioneering the Future of Scientific Progress Through Open Collaboration,” with case studies showing **how open collaboration can strengthen inclusive scientific communities and vice-versa**.
+{{< column >}}
 
 ![BOSC 2023 keynote speaker Sara El-Gebali](/wp-content/uploads/2023/08/image7-768x1024.jpg)
 
-\- Our 2023 keynote speakers both discussed topics related to inclusion and equity. The first [BOSC 2023 keynote](/events/bosc-2023/bosc-2023-keynotes/) was delivered by Sara El-Gebali, who spoke inspiringly about “A New Odyssey: Pioneering the Future of Scientific Progress Through Open Collaboration,” with case studies showing how open collaboration can strengthen inclusive scientific communities and vice-versa.
+{{< endcolumns >}}
+
+{{< columns >}}
 
 ![BOSC 2023 keynote speaker Joseph Yracheta](/wp-content/uploads/2023/04/Joseph-Yracheta-300x296.png)
 
-The [2023 keynote by Joseph Yracheta](/events/bosc-2023/bosc-2023-keynotes/), an Amerindigenous scientist, examined thorny questions about the current open data environment and how it impacts American Indian / Native American communities. Joe, the founder of the [Native BioData Consortium](https://nativebio.org/), discussed our ethical responsibilities as people who work on open source tools and open bioinformatics research to ensure that indigenous data is ethically sourced and used.
+{{< column >}}
+The [2023 keynote by Joseph Yracheta](/events/bosc-2023/bosc-2023-keynotes/), an Amerindigenous scientist, examined thorny questions about the current open data environment and how it impacts American Indian / Native American communities. Joe, the founder of the [Native BioData Consortium](https://nativebio.org/), **discussed our ethical responsibilities as people who work on open source tools and open bioinformatics research to ensure that indigenous data is ethically sourced and used**.
+
+{{< endcolumns >}}
+
+{{< columns >}}
+In recognition that not everyone is privileged enough to gift their time, we started **offering honoraria to keynote speakers** in 2021.
+
+The **first talk at BOSC (and, to our knowledge, at ISMB) to be delivered in a language other than English** was given in 2021 by [keynote speaker Thomas Hervé Mboa Nkoudou of Cameroon](/events/bosc-2021/bosc-2021-keynotes/).
+{{< column >}}
 
 ![BOSC 2021 keynote speaker Thomas Hervé Mboa Nkoudou](/wp-content/uploads/2021/04/Thomas-Mboa-300x200.jpg)
 
-\- In recognition that not everyone is privileged enough to gift their time, we started offering honoraria to keynote speakers in 2021.
+{{< endcolumns >}}
 
-\- The first talk at BOSC (and, to our knowledge, at ISMB) to be delivered in a language other than English was given in 2021 by [keynote speaker Thomas Hervé Mboa Nkoudou of Cameroon](/events/bosc-2021/bosc-2021-keynotes/).
+{{< columns >}}
 
 ![BOSC 2023 organizing committee](/wp-content/uploads/2023/03/BOSC2023-org-committee-square-300x293.jpeg)
 
-\- Although there is not a formal rubric for choosing [BOSC organizing committee](/events/bosc-2023/#org-committee) members, diverse representation is a factor in choosing an array of people who will help BOSC appeal to and be accessible to the widest range of participants. The 9 people on the 2023 organizing committee included 4 women, 2 Black people, 2 South Asian people, and one Latin American.
+{{< column >}}
+Although there is not a formal rubric for choosing [BOSC organizing committee](/events/bosc-2023/#org-committee) members, **diverse representation is a factor in choosing an array of people who will help BOSC appeal to and be accessible to the widest range of participants**. The 9 people on the 2023 organizing committee included 4 women, 2 Black people, 2 South Asian people, and one Latin American.
+ BOSC also has a large and diverse review committee, and we **strive to provide fair and constructive feedback to authors**. Our [review process and rubric](https://github.com/OBF/bosc_materials/blob/master/BOSC_review_process.md.) have been published openly since 2020.
 
-\- BOSC has a large and diverse review committee, and we strive to provide fair and constructive feedback to authors. Our [review process and rubric](https://github.com/OBF/bosc_materials/blob/master/BOSC_review_process.md.) have been published openly since 2020.
+{{< endcolumns >}}
+
 
 ![BOSC 2023 participants](/wp-content/uploads/2023/08/image5-1024x629.png)
 
-\- Some recent BOSCs have included DEI-focused sessions such as ["Inclusion & Open Science"](/events/bosc-2022/bosc-2022-schedule) in 2022.
+{{< columns >}}
 
+Some recent BOSCs have included **DEI-focused sessions** such as ["Inclusion & Open Science"](/events/bosc-2022/bosc-2022-schedule) in 2022, and BOSC's landscape of open science includes citizen science, in which the research subjects themselves (for example, those with a disability) participate in the research. [BOSC 2023](/events/bosc-2023/bosc-2023-schedule/) included a talk entitled "AutSPACEs: a co-created and open source citizen science project to improve environments for sensory processing in autistic people". 
+
+In a 2023 ISCBacademy webinar organized by BOSC, Long COVID sufferer and advocate Hannah Wei presented [Lessons from the Patient-Led Research Collaborative](/2023/03/07/iscbacademy-webinar-on-patient-led-research/).
+
+{{< column >}}
 ![Webinar speaker Hannah Wei with moderator Monica Munoz-Torres](/wp-content/uploads/2023/03/Moni-moderating-questions-for-Hannah-Wei-1-266x300.png)
-
-\- BOSC's landscape of open science includes citizen science, in which the research subjects themselves (for example, those with a disability) participate in the research. [BOSC 2023](/events/bosc-2023/bosc-2023-schedule/) included a talk entitled "AutSPACEs: a co-created and open source citizen science project to improve environments for sensory processing in autistic people". In a 2023 ISCBacademy webinar organized by BOSC, Long COVID sufferer and advocate Hannah Wei presented [Lessons from the Patient-Led Research Collaborative](/2023/03/07/iscbacademy-webinar-on-patient-led-research/).
 
 ![BOSC 2023 panelists](/wp-content/uploads/2023/08/2023-panel-1-1-1024x392.png)
 
-\- Panel discussions have included topics relating to inclusion and diversity in open science. BOSC 2015's panel topic was [Open Source, Open Door: increasing diversity in the bioinformatics open source community](/wiki/BOSC_2015_Panel). BOSC 2022 included a panel on [Building and Sustaining Inclusive Open Science Communities](/events/bosc-2022/bosc-2022-panel/). At BOSC 2023, the panel on [Open and Ethical Data Sharing](/events/bosc-2023/bosc-2023-panel/) centered on the idea that we individually, and our scientific societies, can be advocates for better practices in ethical data sharing.
+{{< endcolumns >}}
 
-![Panel on Building and Sustaining Inclusive Open Science Communities: Jason Williams (moderator); panelists Jenea Adams, Monica Munoz-Torres, Rachel Torchet, and Gary Williams; BOSC Chair Nomi Harris](/wp-content/uploads/2022/11/panel-with-Nomi-1-1024x626.jpeg)![Jenea Adams, one of the BOSC 2022 panelists](/wp-content/uploads/2023/07/Jenea-Adams-1-1.png)
+{{< columns >}}
+**Panel discussions have included topics relating to inclusion and diversity in open science**. BOSC 2015's panel topic was [Open Source, Open Door: increasing diversity in the bioinformatics open source community](/wiki/BOSC_2015_Panel). BOSC 2022 included a panel on [Building and Sustaining Inclusive Open Science Communities](/events/bosc-2022/bosc-2022-panel/). At BOSC 2023, the panel on [Open and Ethical Data Sharing](/events/bosc-2023/bosc-2023-panel/) centered on the idea that we individually, and our scientific societies, can be advocates for better practices in ethical data sharing.
 
-\- Inclusion offers mutual advantages: when we give a wider range of people a voice, they benefit from being included and we in turn benefit from their contributions. 2022 panelist [Jenea Adams shared her thoughts in a blog post](/2023/07/10/spotlight-on-diversity-jenea-adams/), commenting, “BOSC not only showcased the remarkable strides made in computational biology but also emphasized the power of collaboration and inclusivity. Through my participation in the panel on Building and Sustaining Inclusive Open Science Communities, I witnessed the true potential of harnessing diverse perspectives to drive innovation and create a sustainable foundation for open science.”
 
-![](/wp-content/uploads/2023/04/BOSC2020-party-attendees1-1024x576.jpg)![](/wp-content/uploads/2023/04/Scott-Andrew-Shade-1-212x300.jpeg)
 
-\- Our 2020 event ( [BCC2020](/2020/08/13/lessons-learned/), which paired BOSC with the Galaxy Community Conference) was groundbreaking for DEI due to being online and presented twice a day for accessibility around the globe, and all videos professionally captioned. Participants at this event hailed from 61 countries, many of which had never been represented before at BOSC.
+{{< column >}}
 
-\- As far as we are aware, BOSC 2022 was the first BOSC, possibly even the first ISMB, to include a service dog, demonstrating tangible progress in our efforts to make BOSC more inclusive and accessible.
+![Panel on Building and Sustaining Inclusive Open Science Communities: Jason Williams (moderator); panelists Jenea Adams, Monica Munoz-Torres, Rachel Torchet, and Gary Williams; BOSC Chair Nomi Harris](/wp-content/uploads/2022/11/panel-with-Nomi-1-1024x626.jpeg)
+
+
+{{< endcolumns >}}
+
+{{< columns >}}
+
+![Jenea Adams, one of the BOSC 2022 panelists](/wp-content/uploads/2023/07/Jenea-Adams-1-1.png)
+
+{{< column >}}
+
+Inclusion offers mutual advantages: when we give a wider range of people a voice, they benefit from being included and we in turn benefit from their contributions. 2022 panelist [Jenea Adams shared her thoughts in a blog post](/2023/07/10/spotlight-on-diversity-jenea-adams/), commenting, “BOSC not only showcased the remarkable strides made in computational biology but also emphasized the power of collaboration and inclusivity. Through my participation in the panel on Building and Sustaining Inclusive Open Science Communities, **I witnessed the true potential of harnessing diverse perspectives to drive innovation and create a sustainable foundation for open science**.”
+
+{{< endcolumns >}}
+
+{{< columns >}}
+
+Our 2020 event ([BCC2020](/2020/08/13/lessons-learned/), which paired BOSC with the Galaxy Community Conference) was groundbreaking for DEI due to being online and presented twice a day for accessibility around the globe, and all videos professionally captioned. Participants at this event hailed from 61 countries, many of which had never been represented before at BOSC.
+
+{{< column >}}
+
+![a grid of faces on a conference call](/wp-content/uploads/2023/04/BOSC2020-party-attendees1-1024x576.jpg)
+
+{{< endcolumns >}}
+
+{{< columns >}}
+As far as we are aware, BOSC 2022 was the first BOSC, possibly even the first ISMB, to include a service dog, demonstrating tangible progress in our efforts to make BOSC more inclusive and accessible.
+
+{{< column >}}
+
+![two people standing on a hallway talking to each other, with a service dog laying on the floor](/wp-content/uploads/2023/04/Scott-Andrew-Shade-1-212x300.jpeg)
+
+{{< endcolumns >}}
 
 **Further reading:** Our annual BOSC reports, published in the open access journal F1000Research, include sections on DEI (see e.g. [https://f1000research.com/articles/11-1034/v1](https://f1000research.com/articles/11-1034/v1) for 2022, or [https://f1000research.com/articles/9-1160/v1](https://f1000research.com/articles/9-1160/v1) for 2021).


### PR DESCRIPTION
As discussed on the migration document and in the hangouts, the EDI page is now under the OBF top-level heading, and I've formatted it to make use of the column layouts to display it more correctly. 

While at it, I also added in missing alt-texts and slightly reworded the opening bit, to reflect that the page is now outside the BOSC-scope.