### PR TITLE
fix board page and menu

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -19,7 +19,7 @@ OBF runs the annual [Bioinformatics Open Source Conference (BOSC)](events/bosc/a
 
 [BOSC 2025](events/bosc-2025/) will be July 21-22, 2025, in Liverpool, UK (as part of [ISMB/ECCB 2025](https://www.iscb.org/ismbeccb2025/home)). [BOSC 2024](events/bosc-2024/) took place July 15-16, 2024, as part of ISMB 2024 in Montréal, Canada.
 
-[Learn More](events/bosc/about/)
+[Learn More](/about/)
 
 {{< column >}}
 

--- a/content/page/about-obf.md
+++ b/content/page/about-obf.md
@@ -6,20 +6,30 @@ cover:
 date: "2019-02-22T08:44:22+00:00"
 guid: https://www.open-bio.org/wp/?page_id=2950
 title: About OBF
-url: /events/bosc-2021/about-2/
+url: /about/
+aliaes:
+  - /events/bosc-2021/about-2/
 
 ---
 # History
 
-## 2000
+{{< columns >}}
 
 ![](/wp-content/uploads/2019/02/pear-transparent.png)
+
+{{< columns >}}
+![](/wp-content/uploads/2019/02/bioperl.jpg)
+![](/wp-content/uploads/2019/02/biojava-1.jpg)
+{{< column >}}
+![](/wp-content/uploads/2019/02/biopython.png)
+{{< endcolumns >}}
+
+{{< column >}}
+## 2000
 
 First Bioinformatics Open Source Conference (BOSC).
 
 ## 2001
-
-![](/wp-content/uploads/2019/02/bioperl.jpg)![](/wp-content/uploads/2019/02/biojava-1.jpg)![](/wp-content/uploads/2019/02/biopython.png)
 
 OBF grows out of volunteer projects BioPerl, BioJava and BioPython and is formally incorporated.
 
@@ -31,9 +41,11 @@ Bylaws enacted for the first time and formal membership created.
 
 OBF becomes an associate project of Software in the Public Interest, Inc., a fiscal sponsorship organization.
 
-![](/wp-content/uploads/2019/02/attendees_stairs-1024x683.jpg)
-
+{{< endcolumns >}}
 # Who we are
+
+
+![](/wp-content/uploads/2019/02/attendees_stairs-1024x683.jpg)
 
 The Open Bioinformatics Foundation (OBF) is a non-profit, volunteer-run group dedicated to promoting the practice and philosophy of Open Source software development and Open Science within the biological research community.
 

--- a/content/page/board.md
+++ b/content/page/board.md
@@ -26,6 +26,7 @@ Associate Professor at Iowa State University. Chair, Function COSI. Early contri
   src="/img/Hilya.jpg"
   alt="Image of Hilyatuz Zahroh"
   title= "[Hilyatuz Zahroh](https://www.linkedin.com/in/hilyatuz-zahroh-6671ab100/)"
+  link= "https://www.linkedin.com/in/hilyatuz-zahroh-6671ab100"
   caption=`
 _At-large Member_ 
 [APBioNET](https://www.apbionet.org/current-exco-officers-2020-2022/) ExCo
@@ -36,6 +37,7 @@ _At-large Member_
   src="/img/Caleb_Kibet_pic.jpg"
   alt="Image of Caleb Kibet"
   title= "[Caleb Kibet](https://kipkurui.github.io/)"
+  link= "https://kipkurui.github.io"
   caption=`
 _At-large Member_ 
 Bioinformatician at the [International Center of Insect Physiology and Ecology, Kenya](http://www.icipe.org/research/research-support-units/molecular-biology-bioinformatics-and-biostatistics); Founder [OpenScienceKE](https://medium.com/openscienceke).
@@ -45,6 +47,7 @@ Bioinformatician at the [International Center of Insect Physiology and Ecology, 
 {{< figure
   src="/img/Hilmar-Lapp-1.jpg"
   alt="Image of Hilmar Lapp"
+  link= "https://lappland.io"
   title= "[Hilmar Lapp](https://lappland.io/)"
   caption=`
 _At-large Member_ 
@@ -76,6 +79,7 @@ _At-large Member_
   src="/img/NH-Sept2022-square-1.png"
   alt="Image of Nomi Harris"
   title= "[Nomi Harris](https://www.linkedin.com/in/nomiharris)"
+  link= "https://www.linkedin.com/in/nomiharris"
   caption=`
 _Secretary_
 Program Manager at the Lawrence Berkeley National Laboratory; [BOSC chair](https://www.open-bio.org/events/bosc/).
@@ -86,6 +90,7 @@ Program Manager at the Lawrence Berkeley National Laboratory; [BOSC chair](https
   src="/img/Heather-Wiencko-1.jpg"
   alt="Image of Heather Wiencko"
   title= "[Heather Wiencko](https://twitter.com/hlwiencko)"
+  link= "https://twitter.com/hlwiencko"
   caption=`
 _Treasurer_
 Software engineer at Hosted Graphite.
@@ -96,6 +101,7 @@ Software engineer at Hosted Graphite.
   src="/img/BastianGreshakeTzovaras.jpg"
   alt="Image of Bastian Greshake Tzovaras"
   title= "[Bastian Greshake Tzovaras](https://tzovar.as)"
+  link= "https://tzovar.as"
   caption=`
 _At-large Member_
 Co-founder of [openSNP](https://opensnp.org) and Director of Research at [Open Humans](https://www.openhumans.org).

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -55,10 +55,12 @@ outputFormats:
     baseName: feed
 menu:
   main:
-    - name: 'About OBF'
-      url: 'events/bosc-2021/about-2'
+    - name: 'OBF'
       identifier: 'about'
       weight: 1
+    - name: 'About OBF'
+      url: 'about'
+      parent: 'about'
     - name: 'Membership'
       parent: 'about'
       url: 'membership'
@@ -106,7 +108,7 @@ menu:
       weight: 8
       parent: 'bosc'
       url: 'events/bosc/sponsors/'
-    - name: 'OBF Event Fellowships'
+    - name: 'Event Awards'
       weight: 3
       url: 'event-awards/'
     - name: 'News'

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -112,11 +112,13 @@
 <script src="{{ "js/photoswipe.min.js" | absURL }}"></script>
 <script src="{{ "js/photoswipe-ui-default.min.js" | absURL }}"></script>
 {{- else -}}
+<!-- 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.2/photoswipe.min.js" integrity="sha384-QELNnmcmU8IR9ZAykt67vGr9/rZJdHbiWi64V88fCPaOohUlHCqUD/unNN0BXSqy" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.2/photoswipe-ui-default.min.js" integrity="sha384-m67o7SkQ1ALzKZIFh4CiTA8tmadaujiTa9Vu+nqPSwDOqHrDmxLezTdFln8077+q" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.2/photoswipe-ui-default.min.js" integrity="sha384-m67o7SkQ1ALzKZIFh4CiTA8tmadaujiTa9Vu+nqPSwDOqHrDmxLezTdFln8077+q" crossorigin="anonymous"></script>-->
 {{- end -}}
+<!--
 <script src="{{ "js/load-photoswipe.js" | absURL }}"></script>
-
+-->
 <!-- Google Custom Search Engine -->
 {{ if .Site.Params.gcse }}
 <script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,102 @@
+{{- if eq .Kind "taxonomyTerm" }}
+  {{- range $key, $value := .Data.Terms.ByCount }}
+    {{- $.Scratch.Add "most_used" (slice $value.Name) }}
+  {{- end }}
+  {{- if not ($.Scratch.Get "most_used") }}
+    {{- $description := printf "A full overview of all pages with %s, ordered by %s" .Data.Plural .Data.Singular | truncate 180 }}
+    {{- $.Scratch.Set "Description" $description }}
+  {{- else }}
+    {{- $description := printf "A full overview of all pages with %s, ordered by %s, such as: %s" .Data.Plural .Data.Singular ( delimit ( $.Scratch.Get "most_used" ) ", " ", and " ) | truncate 180 }}
+    {{- $.Scratch.Set "Description" $description }}
+  {{- end }}
+
+  {{- $title := printf "Overview of all pages with %s, ordered by %s" .Data.Plural .Data.Singular }}
+  {{- $.Scratch.Set "Title" $title }}
+{{- else if eq .Kind "taxonomy" }}
+  {{- $description := printf "Overview of all pages with the %s #%s, such as: %s" .Data.Singular $.Title ( index .Pages 0).Title | truncate 160 }}
+  {{- $.Scratch.Set "Description" $description }}
+
+  {{- $title := printf "Overview of all pages with the %s #%s" .Data.Singular $.Title }}
+  {{- $.Scratch.Set "Title" $title }}
+{{- else }}
+  {{- $.Scratch.Set "Description" ( .Description | default .Params.subtitle | default .Summary ) }}
+  {{- $.Scratch.Set "Title" ( .Title | default .Site.Title ) }}
+{{- end }}
+
+  <meta charset="utf-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+ <!-- Site Title, Description, Author, and Favicon -->
+
+{{ if .IsHome }}
+    {{- with .Site.Params.homeTitle }}
+      <title>{{ . }}</title>
+    {{- end }}
+  {{ else }}
+    {{- with ($.Scratch.Get "Title") }}
+      <title>{{ . }} - {{ $.Site.Params.homeTitle }}</title>
+    {{- end }}
+{{ end }}
+
+{{- with ($.Scratch.Get "Description") }}
+  <meta name="description" content="{{ . }}">
+{{- end }}
+{{- with .Site.Params.author.name }}
+  <meta name="author" content="{{ . }}"/>
+{{- end }}
+{{- partial "seo/main.html" . }}  
+{{- with .Site.Params.favicon }}
+  <link href='{{ . | absURL }}' rel='icon' type='image/x-icon'/>
+{{- end -}}
+<!-- Hugo Version number -->
+  {{ hugo.Generator -}}
+<!-- Links and stylesheets -->
+  <link rel="alternate" href="{{ "feed.xml" | absLangURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
+
+  {{- if .Site.Params.selfHosted -}}
+  <link rel="stylesheet" href="{{ "css/katex.min.css" | absURL }}" />
+  <link rel="stylesheet" href="{{ "fontawesome/css/all.css" | absURL }}" />
+  <link rel="stylesheet" href="{{ "css/bootstrap.min.css" | absURL }}" />
+  {{- else -}}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.7/dist/katex.min.css" integrity="sha384-3UiQGuEI4TTMaFmGIZumfRPtfKQ3trwQE2JgosJxCnGmQpL/lJdjpcHkaaFwHlcI" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v6.6.0/css/all.css" integrity="sha384-h/hnnw1Bi4nbpD6kE7nYfCXzovi622sY5WBxww8ARKwpdLj5kUWjRuyiXaD1U2JT" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+  {{- end -}}
+
+  <link rel="stylesheet" href="{{ "css/main.css" | absURL }}" />
+
+  {{- if .Site.Params.staticman -}}
+  <link rel="stylesheet" href="{{ "css/staticman.css" | absURL }}" />
+  {{- end -}}
+
+  {{- if .Site.Params.selfHosted -}}
+  <link rel="stylesheet" href="{{ "css/fonts.css" | absURL }}" />
+  {{- else -}}
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800" />
+  {{- end -}}
+
+  {{- if .Site.Params.useHLJS }}
+  <link rel="stylesheet" href="{{ "css/highlight.min.css" | absURL }}" />
+  {{- else -}}
+  <link rel="stylesheet" href="{{ "css/syntax.css" | absURL }}" />
+  {{- end -}}
+  <link rel="stylesheet" href="{{ "css/codeblock.css" | absURL }}" />
+  
+  {{- if .Site.Params.staticman.recaptcha -}}
+  <script src='https://www.google.com/recaptcha/api.js'></script>
+  {{- end -}}
+
+  {{- if .Site.Params.selfHosted -}}
+  <link rel="stylesheet" href="{{ "css/photoswipe.min.css" | absURL }}" />
+  <link rel="stylesheet" href="{{ "css/photoswipe.default-skin.min.css" | absURL }}" />
+  {{- else -}}
+<!--  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.2/photoswipe.min.css" integrity="sha384-h/L2W9KefUClHWaty3SLE5F/qvc4djlyR4qY3NUV5HGQBBW7stbcfff1+I/vmsHh" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.2/default-skin/default-skin.min.css" integrity="sha384-iD0dNku6PYSIQLyfTOpB06F2KCZJAKLOThS5HRe8b3ibhdEQ6eKsFf/EeFxdOt5R" crossorigin="anonymous"> -->
+  {{- end -}}
+
+{{- partial "head_custom.html" . }}
+{{- if not hugo.IsServer -}}
+  {{ template "_internal/google_analytics.html" . }}
+{{- end -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,0 +1,89 @@
+
+{{ if .IsHome }}
+  {{ if .Site.Params.homeTitle }}{{ $.Scratch.Set "title" .Site.Params.homeTitle }}{{ else }}{{ $.Scratch.Set "title" .Site.Title }}{{ end }}
+  {{ if .Site.Params.subtitle }}{{ $.Scratch.Set "subtitle" .Site.Params.subtitle }}{{ end }}
+  {{ if .Site.Params.bigimg }}{{ $.Scratch.Set "bigimg" .Site.Params.bigimg }}{{ end }}
+{{ else }}
+  {{ $.Scratch.Set "title" .Title }}
+  {{ if .Params.subtitle }}{{ $.Scratch.Set "subtitle" .Params.subtitle }}{{ end }}
+  {{ if .Params.bigimg }}{{ $.Scratch.Set "bigimg" .Params.bigimg }}{{ end }}
+{{ end }}
+{{ $bigimg := $.Scratch.Get "bigimg" }}
+{{ $title := $.Scratch.Get "title" }}
+{{ $subtitle := $.Scratch.Get "subtitle" }}
+
+{{ if or $bigimg $title }}
+  {{ if $bigimg }}
+    <div id="header-big-imgs" data-num-img={{len $bigimg}}
+      {{range $i, $img := $bigimg}}
+         {{ if (fileExists $img.src)}}
+          data-img-src-{{add $i 1}}="{{$img.src | absURL }}"
+         {{else}}
+          data-img-src-{{add $i 1}}="{{$img.src}}"
+         {{end}}
+         {{ if $img.desc}}data-img-desc-{{add $i 1}}="{{$img.desc}}"{{end}}
+      {{end}}></div>
+  {{ end }}
+
+  <header class="header-section {{ if $bigimg }}has-img{{ end }}">
+    {{ if $bigimg }}
+      {{ $firstimg := index $bigimg 0 }}
+      <div class="intro-header big-img" style="background-image: url('{{$firstimg.src}}');">
+        {{ $subtitle := $.Scratch.Get "subtitle" }}
+        <div class="container">
+          <div class="row">
+            <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+              <div class="{{ .Type }}-heading">
+                <h1>{{ with $.Scratch.Get "title" }}{{.}}{{ else }}<br/>{{ end }}</h1>
+                  {{ if $subtitle }}
+                    {{ if eq .Type "page" }}
+                      <hr class="small">
+                      <span class="{{ .Type }}-subheading">{{ $subtitle }}</span>
+                    {{ else }}
+                      <h2 class="{{ .Type }}-subheading">{{ $subtitle }}</h2>
+                    {{ end }}
+                  {{ end }}
+                  {{ if eq .Type "post" }}
+                    {{ partial "post_meta.html" . }}
+                  {{ end }}
+              </div>
+            </div>
+          </div>
+        </div>
+        <span class="img-desc" style="display: {{ cond (isset $firstimg "desc") "inline" "none"}};">{{$firstimg.desc}}</span>
+      </div>
+    {{end}}
+    {{ if $title }}
+    <div class="intro-header no-img">
+      <div class="container">
+        <div class="row">
+          <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+            <div class="{{ .Type }}-heading">
+              {{ if eq .Type "list" }}
+                <h1>{{ if .Data.Singular }}#{{ end }}{{ .Title }}</h1>
+              {{ else }}
+                <h1>{{ with $title }}{{.}}{{ else }}<br/>{{ end }}</h1>
+              {{ end }}
+              {{ if ne .Type "post" }}
+                <hr class="small">
+              {{ end }}
+              {{ if $subtitle }}
+                {{ if eq .Type "page" }}
+                  <span class="{{ .Type }}-subheading">{{ $subtitle }}</span>
+                {{ else }}
+                  <h2 class="{{ .Type }}-subheading">{{ $subtitle }}</h2>
+                {{ end }}
+              {{ end }}
+              {{ if eq .Type "post" }}
+                {{ partial "post_meta.html" . }}
+              {{ end }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  {{ end }}
+  </header>
+{{ else }}
+  <div class="intro-header"></div>
+{{ end }}


### PR DESCRIPTION
This closes #32 and #31 

Getting the "OBF history" menu item to load was rather trivial, and I also formatted that page. 

Getting the board member images to not be the gallery page was not as trivial and required effectively ripping out that hover/open gallery effect. I think that's fine as I don't see us using it any time soon, but I want to highlight that this is yet another "deeper" customization in the theme.  

On the positive side: if we ever decide to go back to having those galleries, we just need to delete 

* `layouts/partials/head.html`
* `layouts/partials/header.html`

and then remove the comment in `layouts/partials/footer.html` that currently disables the loading of the JS.