### PR TITLE
fix bosc category

### DIFF
--- a/content/posts/5-tips-to-promote-water-cooler-effects-at-informal-discussion-sessions.md
+++ b/content/posts/5-tips-to-promote-water-cooler-effects-at-informal-discussion-sessions.md
@@ -2,7 +2,7 @@
 author: malvikasharan
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - travel-fellowship
 cover:

--- a/content/posts/a-software-engineer-s-experience-at-bcc-2020.md
+++ b/content/posts/a-software-engineer-s-experience-at-bcc-2020.md
@@ -2,7 +2,7 @@
 author: edidiongmichael08
 category:
   - bcc
-  - bosc/ismb
+  - bosc
   - travel-fellowship
 date: "2020-08-16T11:55:53+00:00"
 guid: https://www.open-bio.org/?p=4902

--- a/content/posts/announcing-bosc-2025-seeking-keynote-speaker-nominations.md
+++ b/content/posts/announcing-bosc-2025-seeking-keynote-speaker-nominations.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - events
 cover:
   alt: BOSC audience with Jessica - 1
@@ -10,7 +10,7 @@ date: "2025-01-09T06:33:54+00:00"
 guid: https://www.open-bio.org/?p=8410
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - conferences
 title: Announcing BOSC 2025; seeking keynote speaker nominations
 url: /2025/01/09/nominate-keynotes-bosc2025/

--- a/content/posts/ariel-mundo-ortiz-my-participation-at-bosc-2021-sponsored-by-the-bosc-obf-event-support.md
+++ b/content/posts/ariel-mundo-ortiz-my-participation-at-bosc-2021-sponsored-by-the-bosc-obf-event-support.md
@@ -1,7 +1,7 @@
 ---
 author: aimundo
 category:
-  - bosc/ismb
+  - bosc
   - community
   - event-fellowship
 date: "2021-09-08T02:43:46+00:00"

--- a/content/posts/bcc2020-inc-bosc-2020-abstracts-due-this-week.md
+++ b/content/posts/bcc2020-inc-bosc-2020-abstracts-due-this-week.md
@@ -1,7 +1,7 @@
 ---
 author: peterc
 category:
-  - bosc/ismb
+  - bosc
   - community
 date: "2020-05-03T12:28:23+00:00"
 guid: https://www.open-bio.org/?p=4724

--- a/content/posts/bcc2020-pre-conference-open-house.md
+++ b/content/posts/bcc2020-pre-conference-open-house.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
   - events
 cover:

--- a/content/posts/bioinformatics-open-source-conference-bosc-2011-call-for-abstracts.md
+++ b/content/posts/bioinformatics-open-source-conference-bosc-2011-call-for-abstracts.md
@@ -1,7 +1,7 @@
 ---
 author: peterc
 category:
-  - bosc/ismb
+  - bosc
   - community
   - obf
 date: "2011-03-04T15:42:59+00:00"

--- a/content/posts/bioperl-interview-in-latest-floss-weekly.md
+++ b/content/posts/bioperl-interview-in-latest-floss-weekly.md
@@ -2,7 +2,7 @@
 author: cjfields
 category:
   - bioperl
-  - bosc/ismb
+  - bosc
   - code
   - community
   - development

--- a/content/posts/biopython-1-62-released.md
+++ b/content/posts/biopython-1-62-released.md
@@ -2,7 +2,7 @@
 author: peterc
 category:
   - biopython
-  - bosc/ismb
+  - bosc
   - code
   - community
   - development

--- a/content/posts/biopython-1-83-released.md
+++ b/content/posts/biopython-1-83-released.md
@@ -12,7 +12,7 @@ date: "2024-01-10T13:46:10+00:00"
 guid: https://www.open-bio.org/?p=7593
 tag:
   - biopython
-  - bosc/ismb
+  - bosc
   - open-source
 title: Biopython 1.83 released
 url: /2024/01/10/biopython-1-83-released/

--- a/content/posts/birds-of-a-feather-at-bosc-2021-deadline-june-25.md
+++ b/content/posts/birds-of-a-feather-at-bosc-2021-deadline-june-25.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
 cover:
   alt: partridge-and-pears-stamp
   image: /wp-content/uploads/2021/06/partridge-and-pears-stamp.png

--- a/content/posts/bosc-2003-pictures-are-online.md
+++ b/content/posts/bosc-2003-pictures-are-online.md
@@ -2,7 +2,7 @@
 author: dag
 category:
   - bioperl
-  - bosc/ismb
+  - bosc
   - general
 date: "2003-07-02T04:59:11+00:00"
 guid: http://news.open-bio.org/news/?p=105

--- a/content/posts/bosc-2005.md
+++ b/content/posts/bosc-2005.md
@@ -1,7 +1,7 @@
 ---
 author: stajich
 category:
-  - bosc/ismb
+  - bosc
 date: "2005-01-29T16:48:50+00:00"
 guid: http://news.open-bio.org/news/?p=128
 title: BOSC 2005

--- a/content/posts/bosc-2008-is-on.md
+++ b/content/posts/bosc-2008-is-on.md
@@ -1,7 +1,7 @@
 ---
 author: hilmar
 category:
-  - bosc/ismb
+  - bosc
 date: "2008-02-18T15:35:07+00:00"
 guid: http://news.open-bio.org/news/?p=145
 summary: Our application to hold BOSC as a two-day SIG (Special Interest Group) meeting in conjunction with ISMB has been accepted for this year. BOSC will take place July 18 and 19 in Toronto, Canada.

--- a/content/posts/bosc-2009-accepted-by-ismb.md
+++ b/content/posts/bosc-2009-accepted-by-ismb.md
@@ -1,12 +1,12 @@
 ---
 author: hilmar
 category:
-  - bosc/ismb
+  - bosc
 date: "2009-01-07T17:07:10+00:00"
 guid: http://news.open-bio.org/news/?p=226
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
 title: BOSC 2009 accepted by ISMB
 url: /2009/01/07/bosc-2009-accepted-by-ismb/
 

--- a/content/posts/bosc-2009-call-for-abstracts.md
+++ b/content/posts/bosc-2009-call-for-abstracts.md
@@ -1,7 +1,7 @@
 ---
 author: kdahlquist
 category:
-  - bosc/ismb
+  - bosc
   - code
   - community
   - development

--- a/content/posts/bosc-2010-call-for-abstracts.md
+++ b/content/posts/bosc-2010-call-for-abstracts.md
@@ -1,7 +1,7 @@
 ---
 author: kdahlquist
 category:
-  - bosc/ismb
+  - bosc
   - community
   - obf
   - obf-projects

--- a/content/posts/bosc-2010-proceedings-published-today-in-bmc-bioinformatics.md
+++ b/content/posts/bosc-2010-proceedings-published-today-in-bmc-bioinformatics.md
@@ -1,7 +1,7 @@
 ---
 author: kdahlquist
 category:
-  - bosc/ismb
+  - bosc
   - community
   - obf
 date: "2010-12-21T19:29:42+00:00"

--- a/content/posts/bosc-2010-request-for-input.md
+++ b/content/posts/bosc-2010-request-for-input.md
@@ -1,7 +1,7 @@
 ---
 author: kdahlquist
 category:
-  - bosc/ismb
+  - bosc
   - community
   - general
   - obf

--- a/content/posts/bosc-2013.md
+++ b/content/posts/bosc-2013.md
@@ -2,7 +2,7 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - obf
   - obf-projects
@@ -10,7 +10,7 @@ date: "2013-07-17T14:33:58+00:00"
 guid: http://news.open-bio.org/news/?p=1030
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
 title: BOSC 2013
 url: /2013/07/17/bosc-2013/
 

--- a/content/posts/bosc-2014-call-for-abstracts.md
+++ b/content/posts/bosc-2014-call-for-abstracts.md
@@ -2,14 +2,14 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - obf
 date: "2014-03-04T18:18:57+00:00"
 guid: http://news.open-bio.org/news/?p=1133
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
 title: BOSC 2014 call for abstracts
 url: /2014/03/04/bosc-2014-call-for-abstracts/
 

--- a/content/posts/bosc-2014-keynote-competition.md
+++ b/content/posts/bosc-2014-keynote-competition.md
@@ -2,7 +2,7 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - general
   - humor
@@ -11,7 +11,7 @@ date: "2013-12-13T12:24:53+00:00"
 guid: http://news.open-bio.org/news/?p=1082
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - community
   - conferences
   - news

--- a/content/posts/bosc-2014-keynote-speakers.md
+++ b/content/posts/bosc-2014-keynote-speakers.md
@@ -2,7 +2,7 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - general
   - obf
@@ -10,7 +10,7 @@ date: "2013-12-24T05:34:18+00:00"
 guid: http://news.open-bio.org/news/?p=1099
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - community
   - conferences
   - news

--- a/content/posts/bosc-2014-video-recording.md
+++ b/content/posts/bosc-2014-video-recording.md
@@ -6,7 +6,7 @@ date: "2014-06-19T15:56:18+00:00"
 guid: http://news.open-bio.org/news/?p=1189
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - conferences
 title: BOSC 2014 video recording
 url: /2014/06/19/bosc-2014-video-recording/

--- a/content/posts/bosc-2015-call-for-abstracts.md
+++ b/content/posts/bosc-2015-call-for-abstracts.md
@@ -2,7 +2,7 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - development
   - general
@@ -11,7 +11,7 @@ date: "2015-03-05T21:00:11+00:00"
 guid: http://news.open-bio.org/news/?p=1279
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - community
   - conferences
   - meeting

--- a/content/posts/bosc-2015-keynote-speakers.md
+++ b/content/posts/bosc-2015-keynote-speakers.md
@@ -2,7 +2,7 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - general
   - obf
@@ -11,7 +11,7 @@ date: "2015-03-26T16:05:48+00:00"
 guid: http://news.open-bio.org/news/?p=1291
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - community
   - obf
 title: BOSC 2015 Keynote Speakers

--- a/content/posts/bosc-2015-panel-increasing-diversity.md
+++ b/content/posts/bosc-2015-panel-increasing-diversity.md
@@ -2,14 +2,14 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - obf
 date: "2015-06-05T10:29:46+00:00"
 guid: http://news.open-bio.org/news/?p=1320
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - community
 title: BOSC 2015 Panel - increasing diversity
 url: /2015/06/05/bosc-2015-panel-increasing-diversity/

--- a/content/posts/bosc-2015-will-be-in-dublin-with-ismb-eccb-2015.md
+++ b/content/posts/bosc-2015-will-be-in-dublin-with-ismb-eccb-2015.md
@@ -2,14 +2,14 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - obf
 date: "2014-09-18T09:42:06+00:00"
 guid: http://news.open-bio.org/news/?p=1203
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - community
   - conferences
 title: BOSC 2015 will be in Dublin with ISMB/ECCB 2015

--- a/content/posts/bosc-2016-call-for-abstracts.md
+++ b/content/posts/bosc-2016-call-for-abstracts.md
@@ -2,7 +2,7 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - development
   - obf
@@ -10,7 +10,7 @@ date: "2016-03-01T17:42:48+00:00"
 guid: https://news.obf.io/?p=1460
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - codefest
   - community
 title: BOSC 2016 Call for Abstracts

--- a/content/posts/bosc-2016-in-disney-world-with-donald-docker.md
+++ b/content/posts/bosc-2016-in-disney-world-with-donald-docker.md
@@ -1,7 +1,7 @@
 ---
 author: dimitras
 category:
-  - bosc/ismb
+  - bosc
   - community
   - obf
   - travel-fellowship

--- a/content/posts/bosc-2016-keynote-speakers.md
+++ b/content/posts/bosc-2016-keynote-speakers.md
@@ -2,7 +2,7 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - general
   - obf
@@ -11,7 +11,7 @@ date: "2016-03-22T12:10:51+00:00"
 guid: https://news.open-bio.org/?p=1479
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - community
   - obf
 title: BOSC 2016 Keynote Speakers

--- a/content/posts/bosc-2016-panel-growing-and-sustaining-open-source-communities.md
+++ b/content/posts/bosc-2016-panel-growing-and-sustaining-open-source-communities.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
 date: "2016-05-27T16:45:21+00:00"
 guid: https://news.open-bio.org/?p=1506

--- a/content/posts/bosc-2017-in-prague-the-land-of-stories-and-beer.md
+++ b/content/posts/bosc-2017-in-prague-the-land-of-stories-and-beer.md
@@ -2,7 +2,7 @@
 author: farahzk
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - essays
   - obf
@@ -12,7 +12,7 @@ guid: https://news.open-bio.org/?p=1767
 summary: _This is a guest blog post from Farah Zaib Khan, who was supported by the ongoing [Open Bioinformatics Foundation travel fellowship program](https://github.com/OBF/obf-docs/blob/master/Travel_fellowships.md) to attend our annual conference BOSC 2017 and its preceding Codefest in Prague, July 2017. The OBF’s Travel Fellowship program continues to help open source bioinformatics software developers with funding to attend conferences or workshops. The current call closes 15 December 2017, you might want to apply?_
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - community
   - conferences
   - meeting

--- a/content/posts/bosc-2017-keynote-speakers.md
+++ b/content/posts/bosc-2017-keynote-speakers.md
@@ -2,13 +2,13 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
 date: "2017-04-13T10:28:24+00:00"
 guid: https://news.open-bio.org/?p=1611
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - community
   - conferences
 title: BOSC 2017 keynote speakers

--- a/content/posts/bosc-2017-report.md
+++ b/content/posts/bosc-2017-report.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - events
 date: "2017-10-28T23:01:19+00:00"
 guid: https://news.open-bio.org/?p=1771

--- a/content/posts/bosc-2020-will-be-online.md
+++ b/content/posts/bosc-2020-will-be-online.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
   - events
 cover:

--- a/content/posts/bosc-2021-will-be-part-of-ismb-eccb-2021-online.md
+++ b/content/posts/bosc-2021-will-be-part-of-ismb-eccb-2021-online.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - events
   - uncategorized
 cover:
@@ -11,7 +11,7 @@ date: "2021-02-12T06:22:49+00:00"
 guid: https://www.open-bio.org/?p=5271
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
 title: BOSC 2021 will be part of ISMB/ECCB 2021 (online)
 url: /2021/02/12/bosc-2021-will-be-part-of-ismb-eccb-2021-online/
 

--- a/content/posts/bosc-2023-report.md
+++ b/content/posts/bosc-2023-report.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - cofest
   - community
   - events

--- a/content/posts/bosc-2024-review-committee.md
+++ b/content/posts/bosc-2024-review-committee.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
 cover:
   alt: pear-reviewers
   image: /wp-content/uploads/2024/04/pear-reviewers.jpg

--- a/content/posts/bosc-2024-videos-now-available.md
+++ b/content/posts/bosc-2024-videos-now-available.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
 cover:
   alt: BOSC-room - 1
   image: /wp-content/uploads/2024/08/BOSC-room-1.jpeg

--- a/content/posts/bosc-2025-potential-keynote-speakers-community-comment-period-open.md
+++ b/content/posts/bosc-2025-potential-keynote-speakers-community-comment-period-open.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: Jason at mic cropped - 1
@@ -10,7 +10,7 @@ date: "2025-01-18T00:19:29+00:00"
 guid: https://www.open-bio.org/?p=8444
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - conferences
 title: BOSC 2025 potential keynote speakers–community comment period open
 url: /2025/01/18/2025-keynote-community-comment/

--- a/content/posts/bosc-abstract-parties.md
+++ b/content/posts/bosc-abstract-parties.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: Screen Shot 2021-04-09 at 9.08.02 AM

--- a/content/posts/bosc-and-bio-ontologies-even-better-together.md
+++ b/content/posts/bosc-and-bio-ontologies-even-better-together.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: ISMB-Bio-Ontologies-BOSC
@@ -10,7 +10,7 @@ date: "2022-03-02T04:52:45+00:00"
 guid: https://www.open-bio.org/?p=6267
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - conferences
   - ontologies
   - open-source

--- a/content/posts/bosc-codefest-2016.md
+++ b/content/posts/bosc-codefest-2016.md
@@ -2,7 +2,7 @@
 author: brad
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - development
   - general
@@ -13,7 +13,7 @@ date: "2016-03-28T13:56:07+00:00"
 guid: https://news.open-bio.org/?p=1484
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - community
   - development
   - meeting

--- a/content/posts/bosc-collaborationfest-2023-report.md
+++ b/content/posts/bosc-collaborationfest-2023-report.md
@@ -1,7 +1,7 @@
 ---
 author: jeremy.just
 category:
-  - bosc/ismb
+  - bosc
   - cofest
   - community
   - events
@@ -13,7 +13,7 @@ date: "2023-09-29T22:08:37+00:00"
 guid: https://www.open-bio.org/?p=7341
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - codefest
   - cofest
   - europe

--- a/content/posts/bosc-early-poster-acceptance.md
+++ b/content/posts/bosc-early-poster-acceptance.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
 cover:
   alt: accepted
   image: /wp-content/uploads/2023/03/accepted.jpeg

--- a/content/posts/bosc-finishes-and-i-weep-as-i-miss-it-already.md
+++ b/content/posts/bosc-finishes-and-i-weep-as-i-miss-it-already.md
@@ -1,7 +1,7 @@
 ---
 author: brad
 category:
-  - bosc/ismb
+  - bosc
 date: "2003-06-28T11:08:51+00:00"
 guid: http://news.open-bio.org/news/?p=103
 summary: BOSC always comes and goes so fast. I am a melancholy kind of guy so whenever things finish up I get a little misty eyed with regrets at the things I could have done and the people I could have met. But it was all so great it makes me smile with the understanding of the entire world. Plus weeping really gets you the women -- makes you look quite sensitive. And I am all about sensitivity. But before I got into this mindset, I tried to write down what happened. Read and feel my joy.

--- a/content/posts/bosc-late-poster-abstract-deadline-is-june-3.md
+++ b/content/posts/bosc-late-poster-abstract-deadline-is-june-3.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: Colour Horizontal Full Name

--- a/content/posts/bosc-late-round-abstract-submission-closes-may-15.md
+++ b/content/posts/bosc-late-round-abstract-submission-closes-may-15.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - events
 cover:
   alt: bosc-crowd-nh-at-podium-by-berenice-batut - 1
@@ -10,7 +10,7 @@ date: "2019-05-09T23:48:35+00:00"
 guid: https://www.open-bio.org/?p=3543
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - open-source
 title: BOSC late-round abstract submission closes May 15!
 url: /2019/05/09/bosc-2019-late-round/

--- a/content/posts/bosc-obf-2021-event-support-fund.md
+++ b/content/posts/bosc-obf-2021-event-support-fund.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
   - event-fellowship
 cover:

--- a/content/posts/bosc-schedule-posted-1.md
+++ b/content/posts/bosc-schedule-posted-1.md
@@ -1,14 +1,14 @@
 ---
 author: kdahlquist
 category:
-  - bosc/ismb
+  - bosc
   - community
   - obf
 date: "2009-06-02T02:09:18+00:00"
 guid: http://news.open-bio.org/news/2009/06/bosc-schedule-posted-2/
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
 title: BOSC Schedule Posted
 url: /2009/06/01/bosc-schedule-posted-2/
 

--- a/content/posts/bosc-schedule-posted.md
+++ b/content/posts/bosc-schedule-posted.md
@@ -1,7 +1,7 @@
 ---
 author: stajich
 category:
-  - bosc/ismb
+  - bosc
 date: "2005-06-16T23:52:45+00:00"
 guid: http://news.open-bio.org/news/?p=132
 title: BOSC Schedule Posted

--- a/content/posts/bosc-update-ruttenberg-hanmer-confirmed-as-keynotes-early-registration-deadline-friday.md
+++ b/content/posts/bosc-update-ruttenberg-hanmer-confirmed-as-keynotes-early-registration-deadline-friday.md
@@ -1,7 +1,7 @@
 ---
 author: kdahlquist
 category:
-  - bosc/ismb
+  - bosc
   - community
   - general
 date: "2009-05-14T01:12:53+00:00"

--- a/content/posts/bosc-welcomes-sarah-hird-as-outreach-coordinator.md
+++ b/content/posts/bosc-welcomes-sarah-hird-as-outreach-coordinator.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
 date: "2015-01-05T03:56:15+00:00"
 guid: http://news.open-bio.org/news/?p=1235

--- a/content/posts/call-for-abstracts-for-bosc-2012.md
+++ b/content/posts/call-for-abstracts-for-bosc-2012.md
@@ -2,7 +2,7 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - obf
   - obf-projects

--- a/content/posts/call-for-applications-for-obf-event-fellowship-round-1-of-2021.md
+++ b/content/posts/call-for-applications-for-obf-event-fellowship-round-1-of-2021.md
@@ -1,7 +1,7 @@
 ---
 author: malvikasharan
 category:
-  - bosc/ismb
+  - bosc
   - event-fellowship
   - events
 cover:

--- a/content/posts/call-for-obf-travel-fellowship-is-open-until-1-december-2019.md
+++ b/content/posts/call-for-obf-travel-fellowship-is-open-until-1-december-2019.md
@@ -1,7 +1,7 @@
 ---
 author: malvikasharan
 category:
-  - bosc/ismb
+  - bosc
   - community
   - travel-fellowship
 cover:

--- a/content/posts/call-for-the-second-round-of-obf-event-fellowship-2023-and-the-first-2023-round-overview.md
+++ b/content/posts/call-for-the-second-round-of-obf-event-fellowship-2023-and-the-first-2023-round-overview.md
@@ -10,7 +10,7 @@ cover:
 date: "2023-07-05T05:05:05+00:00"
 guid: https://www.open-bio.org/?p=7164
 tag:
-  - bosc/ismb
+  - bosc
   - travel-fellowship
 title: Call for the second round of OBF Event Fellowship 2023 and the first 2023 round overview.
 url: /2023/07/05/call-for-event-fellowship-round-2-2023/

--- a/content/posts/catering-at-bosc-codefest-2014.md
+++ b/content/posts/catering-at-bosc-codefest-2014.md
@@ -2,7 +2,7 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - code
   - community
   - development
@@ -13,7 +13,7 @@ date: "2014-04-02T11:13:25+00:00"
 guid: http://news.open-bio.org/news/?p=1153
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - code
   - codefest
   - community

--- a/content/posts/city-of-roses-they-call-it-portland-oregon-usa.md
+++ b/content/posts/city-of-roses-they-call-it-portland-oregon-usa.md
@@ -2,7 +2,7 @@
 author: farahzk
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - obf
   - travel-fellowship

--- a/content/posts/collaborationfest-2022.md
+++ b/content/posts/collaborationfest-2022.md
@@ -1,7 +1,7 @@
 ---
 author: admin
 category:
-  - bosc/ismb
+  - bosc
   - community
   - obf
 date: "2022-05-17T18:53:30+00:00"

--- a/content/posts/comment-period-on-potential-bosc-2023-keynote-speakers-is-now-open.md
+++ b/content/posts/comment-period-on-potential-bosc-2023-keynote-speakers-is-now-open.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
 cover:
   alt: BOSC-color-logo-with-BOSC-smaller
   image: /wp-content/uploads/2021/03/BOSC-color-logo-with-BOSC-smaller.jpeg
@@ -9,7 +9,7 @@ date: "2023-02-10T22:44:40+00:00"
 guid: https://www.open-bio.org/?p=6860
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - community
   - conferences
 title: Comment period on potential BOSC 2023 keynote speakers is now open

--- a/content/posts/community-comment-period-open-for-potential-bosc-2024-keynotes.md
+++ b/content/posts/community-comment-period-open-for-potential-bosc-2024-keynotes.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: pears-commenting

--- a/content/posts/computational-biology-without-borders.md
+++ b/content/posts/computational-biology-without-borders.md
@@ -1,7 +1,7 @@
 ---
 author: azizk
 category:
-  - bosc/ismb
+  - bosc
   - travel-fellowship
 cover:
   alt: Basel-bridge
@@ -10,7 +10,7 @@ date: "2019-10-15T20:52:03+00:00"
 guid: https://www.open-bio.org/?p=3850
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - community
   - conferences
   - open-source

--- a/content/posts/cordon-bleu-bioinformatics.md
+++ b/content/posts/cordon-bleu-bioinformatics.md
@@ -1,7 +1,7 @@
 ---
 author: saketkc
 category:
-  - bosc/ismb
+  - bosc
   - travel-fellowship
 cover:
   alt: cordon-bleu

--- a/content/posts/crowdsourced-highlights-from-bosc-2022.md
+++ b/content/posts/crowdsourced-highlights-from-bosc-2022.md
@@ -1,7 +1,7 @@
 ---
 author: vdauwera
 category:
-  - bosc/ismb
+  - bosc
   - cofest
   - event-fellowship
 cover:
@@ -11,7 +11,7 @@ date: "2022-08-16T00:08:42+00:00"
 guid: https://www.open-bio.org/?p=6592
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - cofest
   - community
   - conferences

--- a/content/posts/david-twesigomwe-my-bosc-2021-experience.md
+++ b/content/posts/david-twesigomwe-my-bosc-2021-experience.md
@@ -1,7 +1,7 @@
 ---
 author: twesigomwedavid
 category:
-  - bosc/ismb
+  - bosc
   - community
   - event-fellowship
 cover:

--- a/content/posts/early-poster-acceptance-round-2024.md
+++ b/content/posts/early-poster-acceptance-round-2024.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
 cover:
   alt: pears-with-posters1
   image: /wp-content/uploads/2024/02/pears-with-posters1.jpg
@@ -9,7 +9,7 @@ date: "2024-02-18T23:20:16+00:00"
 guid: https://www.open-bio.org/?p=7670
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
 title: Early Poster Acceptance Round 2024
 url: /2024/02/18/early-poster-acceptance-2024/
 

--- a/content/posts/festus-nyasimi-journey-to-the-ismb-bosc-2022-conference.md
+++ b/content/posts/festus-nyasimi-journey-to-the-ismb-bosc-2022-conference.md
@@ -1,7 +1,7 @@
 ---
 author: fnyasimi
 category:
-  - bosc/ismb
+  - bosc
   - event-fellowship
   - travel-fellowship
 cover:

--- a/content/posts/first-three-obf-travel-fellowships-awarded.md
+++ b/content/posts/first-three-obf-travel-fellowships-awarded.md
@@ -2,7 +2,7 @@
 author: nlharris
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - obf
   - travel-fellowship

--- a/content/posts/following-up-from-bosc-s-obf-birds-of-a-feather-meeting.md
+++ b/content/posts/following-up-from-bosc-s-obf-birds-of-a-feather-meeting.md
@@ -1,7 +1,7 @@
 ---
 author: yo
 category:
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: Hilmar, Peter, and Yo

--- a/content/posts/free-registration-to-student-presenters-at-bosc-2014.md
+++ b/content/posts/free-registration-to-student-presenters-at-bosc-2014.md
@@ -2,14 +2,14 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - obf
 date: "2014-03-19T18:21:22+00:00"
 guid: http://news.open-bio.org/news/?p=1148
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
 title: Free registration to student presenters at BOSC 2014
 url: /2014/03/19/free-student-presenters-bosc-2014/
 

--- a/content/posts/gccbosc-2018-a-bioinformatics-community-conference-call-for-abstracts.md
+++ b/content/posts/gccbosc-2018-a-bioinformatics-community-conference-call-for-abstracts.md
@@ -2,7 +2,7 @@
 author: peterc
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - obf
 date: "2018-02-21T10:07:04+00:00"
@@ -13,7 +13,7 @@ summary: |-
   We are pleased to announce that abstract submission and early registration for [GCCBOSC2018](https://gccbosc2018.sched.com/) are now open. This event brings our annual **Bioinformatics Open Source Conference** and the **Galaxy Community Conference** together into a unified week-long event. If you work in open source life science or data-intensive biomedical research, then there is no better place than **GCCBOSC 2018** to present your work and to learn from others.
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - codefest
   - community
   - conferences

--- a/content/posts/gccbosc-2018-post-meeting-report.md
+++ b/content/posts/gccbosc-2018-post-meeting-report.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: Presenters and attendees mingle at the GCCBOSC 2018 poster/demo session

--- a/content/posts/gemma-turon-s-iscbacademy-talk-available-on-video.md
+++ b/content/posts/gemma-turon-s-iscbacademy-talk-available-on-video.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - uncategorized
 cover:
   alt: Gemma-screenshot - 1

--- a/content/posts/hannah-wei-webinar-video-now-available.md
+++ b/content/posts/hannah-wei-webinar-video-now-available.md
@@ -2,7 +2,7 @@
 author: nlharris
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - obf
 cover:

--- a/content/posts/help-us-make-bcc2020-a-rewarding-online-experience.md
+++ b/content/posts/help-us-make-bcc2020-a-rewarding-online-experience.md
@@ -2,7 +2,7 @@
 author: nlharris
 category:
   - bcc
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: glowing-laptop-cropped - 1

--- a/content/posts/in-memoriam-galaxy-s-co-founder-james-taylor.md
+++ b/content/posts/in-memoriam-galaxy-s-co-founder-james-taylor.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: 10-taylor_james_2020-200x300

--- a/content/posts/introducing-the-bosc-2021-organizing-committee.md
+++ b/content/posts/introducing-the-bosc-2021-organizing-committee.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: bosc-2021-org-committee-for-website

--- a/content/posts/iscbacademy-gemma-turon-on-open-source-ai-ml-for-antimicrobial-drug-discovery.md
+++ b/content/posts/iscbacademy-gemma-turon-on-open-source-ai-ml-for-antimicrobial-drug-discovery.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
 cover:
   alt: Gemma-Turon - 1
   image: /wp-content/uploads/2024/02/Gemma-Turon-1.png

--- a/content/posts/iscbacademy-webinar-feb-22-yo-yehudi.md
+++ b/content/posts/iscbacademy-webinar-feb-22-yo-yehudi.md
@@ -2,7 +2,7 @@
 author: nlharris
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - uncategorized
 cover:

--- a/content/posts/iscbacademy-webinar-oct-3.md
+++ b/content/posts/iscbacademy-webinar-oct-3.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: Sierra Moxon

--- a/content/posts/iscbacademy-webinar-on-patient-led-research.md
+++ b/content/posts/iscbacademy-webinar-on-patient-led-research.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - events
 cover:
   alt: Hannah_Wei_Profile

--- a/content/posts/iscbacademy-webinar-open-sourcing-ourselves-together-mad-price-ball.md
+++ b/content/posts/iscbacademy-webinar-open-sourcing-ourselves-together-mad-price-ball.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
   - uncategorized
 cover:

--- a/content/posts/join-us-at-bosc-2021.md
+++ b/content/posts/join-us-at-bosc-2021.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
   - event-fellowship
 cover:

--- a/content/posts/join-us-for-bosc-2021.md
+++ b/content/posts/join-us-for-bosc-2021.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: Colour Horizontal Full Name

--- a/content/posts/join-us-for-cofest-2024.md
+++ b/content/posts/join-us-for-cofest-2024.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - cofest
 cover:
   alt: CoFest2023-lunch - 1

--- a/content/posts/julian-lombardi-will-present-keynote-at-bosc-2008.md
+++ b/content/posts/julian-lombardi-will-present-keynote-at-bosc-2008.md
@@ -1,7 +1,7 @@
 ---
 author: hilmar
 category:
-  - bosc/ismb
+  - bosc
 date: "2008-05-18T19:23:50+00:00"
 guid: http://news.open-bio.org/news/?p=148
 title: Julian Lombardi will present keynote at BOSC 2008

--- a/content/posts/lessons-learned-from-organizing-a-virtual-conference-bcc2020.md
+++ b/content/posts/lessons-learned-from-organizing-a-virtual-conference-bcc2020.md
@@ -2,7 +2,7 @@
 author: nlharris
 category:
   - bcc
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: abby-chris-yo-greenroom-whole-room

--- a/content/posts/meeting-report-bosc-2019-the-20th-annual-bosc.md
+++ b/content/posts/meeting-report-bosc-2019-the-20th-annual-bosc.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
   - events
 cover:

--- a/content/posts/my-amazing-bosc-2024-experience.md
+++ b/content/posts/my-amazing-bosc-2024-experience.md
@@ -1,7 +1,7 @@
 ---
 author: beatricemiha
 category:
-  - bosc/ismb
+  - bosc
   - event-fellowship
 cover:
   alt: Beatrice Mihalache with BOSC poster

--- a/content/posts/new-biojava-logo-design-competition.md
+++ b/content/posts/new-biojava-logo-design-competition.md
@@ -3,7 +3,7 @@ author: andreas
 category:
   - biojava
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - development
   - obf
@@ -14,7 +14,7 @@ guid: https://news.open-bio.org/?p=1517
 tag:
   - biojava
   - bosc
-  - bosc/ismb
+  - bosc
   - community
   - development
   - obf

--- a/content/posts/new-obf-logo.md
+++ b/content/posts/new-obf-logo.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
   - obf
   - website

--- a/content/posts/nominate-a-keynote-speaker-for-bosc-2023.md
+++ b/content/posts/nominate-a-keynote-speaker-for-bosc-2023.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
 cover:
   alt: Jason-Williams-keynote2022
   image: /wp-content/uploads/2022/08/image5-e1675318372322.jpg

--- a/content/posts/nominate-a-keynote-speaker-for-bosc.md
+++ b/content/posts/nominate-a-keynote-speaker-for-bosc.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: Jason-Williams-keynote2022

--- a/content/posts/obf-birds-of-a-feather-at-gccbosc-2018.md
+++ b/content/posts/obf-birds-of-a-feather-at-gccbosc-2018.md
@@ -2,7 +2,7 @@
 author: nlharris
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
 date: "2018-06-14T18:11:25+00:00"
 guid: https://news.open-bio.org/?p=1972

--- a/content/posts/obf-travel-fellowship-2020-round-1-and-bcc-2020.md
+++ b/content/posts/obf-travel-fellowship-2020-round-1-and-bcc-2020.md
@@ -1,7 +1,7 @@
 ---
 author: malvikasharan
 category:
-  - bosc/ismb
+  - bosc
   - community
   - obf
   - travel-fellowship

--- a/content/posts/obf-travel-fellowship-bosc-session-of-the-eccb-ismb-2017.md
+++ b/content/posts/obf-travel-fellowship-bosc-session-of-the-eccb-ismb-2017.md
@@ -2,7 +2,7 @@
 author: cjfields
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - travel-fellowship
 date: "2017-08-28T14:43:53+00:00"
@@ -10,7 +10,7 @@ guid: https://news.open-bio.org/?p=1746
 summary: _This blog post is syndicated from a [post on Jonathan Sobel's blog](https://jonathansobel1.wordpress.com/2017/07/27/bosc-session-of-the-eccbismb-2017/), originally published July 27, 2017. Jonathan was supported by the ongoing [OBF travel fellowship program](https://github.com/OBF/obf-docs/blob/master/Travel_fellowships.md) to attend the 2017 Bioinformatics Open Source Conference (BOSC), held as part of the 2017 ISMB/ECCB meeting in Prague, Czech Republic, in July 2017._ _The OBF's Travel Fellowship program continues to help open source bioinformatics software developers with funding to attend conferences, workshops, or training events. The next call closes 15 December 2017._
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - community
   - travel-fellowship
 title: OBF Travel Fellowship - BOSC session of the ECCB/ISMB 2017

--- a/content/posts/obf-travel-fellowship-program.md
+++ b/content/posts/obf-travel-fellowship-program.md
@@ -1,7 +1,7 @@
 ---
 author: hilmar
 category:
-  - bosc/ismb
+  - bosc
   - community
   - obf
   - travel-fellowship

--- a/content/posts/open-source-open-door-increasing-diversity-in-the-bioinformatics-open-source-community.md
+++ b/content/posts/open-source-open-door-increasing-diversity-in-the-bioinformatics-open-source-community.md
@@ -2,14 +2,14 @@
 author: nlharris
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - obf
 date: "2015-04-02T22:09:39+00:00"
 guid: http://news.open-bio.org/news/?p=1297
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - community
   - conferences
   - obf

--- a/content/posts/openbio-solution-challenge-project-updates-at-bosc-2010.md
+++ b/content/posts/openbio-solution-challenge-project-updates-at-bosc-2010.md
@@ -1,7 +1,7 @@
 ---
 author: brad
 category:
-  - bosc/ismb
+  - bosc
   - obf-projects
 date: "2010-01-28T20:45:59+00:00"
 guid: http://news.open-bio.org/news/?p=609

--- a/content/posts/planning-an-online-vs-an-in-person-conference-which-is-harder.md
+++ b/content/posts/planning-an-online-vs-an-in-person-conference-which-is-harder.md
@@ -2,7 +2,7 @@
 author: nlharris
 category:
   - bcc
-  - bosc/ismb
+  - bosc
   - events
   - humor
   - uncategorized

--- a/content/posts/post-bosc-cofest-will-be-online.md
+++ b/content/posts/post-bosc-cofest-will-be-online.md
@@ -1,7 +1,7 @@
 ---
 author: admin
 category:
-  - bosc/ismb
+  - bosc
   - community
 cover:
   alt: online-collaboration - 1

--- a/content/posts/reminder-abstracts-for-bosc-2009-due-april-13.md
+++ b/content/posts/reminder-abstracts-for-bosc-2009-due-april-13.md
@@ -1,13 +1,13 @@
 ---
 author: kdahlquist
 category:
-  - bosc/ismb
+  - bosc
   - obf
   - obf-projects
 date: "2009-04-10T20:41:27+00:00"
 guid: http://news.open-bio.org/news/?p=316
 tag:
-  - bosc/ismb
+  - bosc
   - code
   - community
   - development

--- a/content/posts/reminder-bosc-abstract-deadline-april-15.md
+++ b/content/posts/reminder-bosc-abstract-deadline-april-15.md
@@ -1,7 +1,7 @@
 ---
 author: kdahlquist
 category:
-  - bosc/ismb
+  - bosc
   - community
   - general
   - mailing-lists

--- a/content/posts/slides-of-bioperl-db-biosql-talk-at-bosc03.md
+++ b/content/posts/slides-of-bioperl-db-biosql-talk-at-bosc03.md
@@ -2,7 +2,7 @@
 author: hilmar
 category:
   - bioperl
-  - bosc/ismb
+  - bosc
   - obda-/-biosql
 date: "2003-09-21T09:36:00+00:00"
 guid: http://news.open-bio.org/news/?p=114

--- a/content/posts/strong-spotlight-on-diversity-jenea-adams-strong.md
+++ b/content/posts/strong-spotlight-on-diversity-jenea-adams-strong.md
@@ -1,7 +1,7 @@
 ---
 author: nlharris
 category:
-  - bosc/ismb
+  - bosc
   - community
   - event-fellowship
   - uncategorized

--- a/content/posts/taking-turns.md
+++ b/content/posts/taking-turns.md
@@ -2,14 +2,14 @@
 author: nlharris
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - obf
 date: "2018-08-02T16:55:44+00:00"
 guid: https://news.open-bio.org/?p=2022
 tag:
   - bosc
-  - bosc/ismb
+  - bosc
   - codefest
   - gccbosc
   - meeting

--- a/content/posts/the-color-of-bioinformatics-what-is-it-and-how-can-it-be-modified.md
+++ b/content/posts/the-color-of-bioinformatics-what-is-it-and-how-can-it-be-modified.md
@@ -2,7 +2,7 @@
 author: tendai
 category:
   - blogroll
-  - bosc/ismb
+  - bosc
   - community
   - obf
   - travel-fellowship

--- a/content/posts/they-let-me-into-australia-and-this-is-what-i-saw.md
+++ b/content/posts/they-let-me-into-australia-and-this-is-what-i-saw.md
@@ -1,7 +1,7 @@
 ---
 author: brad
 category:
-  - bosc/ismb
+  - bosc
 date: "2003-06-28T09:26:53+00:00"
 guid: http://news.open-bio.org/news/?p=102
 summary: If you are not lucky enough to be here in wonderfully beautiful Brisbane with beaches next to the river and where every man and woman is a perfect physical specimen, then you can read all about BOSC colored through my mind. Enjoy.

--- a/content/posts/travel-award-recipients-for-april-2017.md
+++ b/content/posts/travel-award-recipients-for-april-2017.md
@@ -1,7 +1,7 @@
 ---
 author: kcranstn
 category:
-  - bosc/ismb
+  - bosc
   - community
   - obf
   - travel-fellowship

--- a/content/posts/watch-the-recording-of-the-iscbacademy-webinar-on-growing-open-source-communities.md
+++ b/content/posts/watch-the-recording-of-the-iscbacademy-webinar-on-growing-open-source-communities.md
@@ -1,7 +1,7 @@
 ---
 author: bgreshake
 category:
-  - bosc/ismb
+  - bosc
   - community
 date: "2022-02-23T08:27:54+00:00"
 guid: https://www.open-bio.org/?p=6211


### PR DESCRIPTION
This replaces all the entries in the `bosc/ismb` category with the simpler `bosc` category to avoid running into potential issues down the line. 