### PR TITLE
Link to full T&C for event awards

### DIFF
--- a/content/page/event-awards.md
+++ b/content/page/event-awards.md
@@ -12,6 +12,8 @@ The Open Bioinformatics Foundation ([OBF](https://open-bio.org)) promotes open s
 
 These fellowships are available to support both in-person and remote (virtual) participation at events such as conferences, workshops, training courses or collaborative development sprints.
 
+This page is a summary of the [official rules and procedures](https://github.com/OBF/obf-docs/blob/master/Travel_fellowships.md), which includes the rubric used to evaluate applications.
+
 _The OBF Event Fellowship was previously offered under the title OBF Travel Fellowship._
 
 ![](/wp-content/uploads/2019/02/anisha-keshavan-conf-1024x755.jpg)


### PR DESCRIPTION
Inserts a brief paragraph at the end of the opening linking to the GitHub document with the full rules, rubric, etc. I'm open to suggestions for working and best placement (e.g. at the end?)

Cross reference https://github.com/OBF/obf-docs/pull/125 - together these make the links between the two pages explicit.