### PR TITLE
Add Event Awards link to OBF menu

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -64,6 +64,11 @@ menu:
     - name: 'Get Involved'
       parent: 'about'
       url: 'get-involved'
+      weight: 5
+    - name: 'OBF Event Awards"
+      parent: 'about'
+      url: /event-awards/
+      weight: 4
     - name: 'Diversity, Equity & Inclusion'
       parent: 'about' 
       url: '/obf-dei/'


### PR DESCRIPTION
I was surprised to see that the OBF main menu doesn't include Event Awards - shouldn't it? (Didn't it, at some point?) So I added it, but I don't fully understand how the weights are used, and particularly how menu items are ordered if they lack weights (as some of them do). So this PR may need some tweaking.