### PR TITLE
Create post for OBF Event Fellowship round 2 announcement

### DIFF
--- a/content/posts/2026-06-24-Event-Awards.md
+++ b/content/posts/2026-06-24-Event-Awards.md
@@ -1,0 +1,46 @@
+---
+author: ckibet
+date: 2026-06-24 # format is YYYY-MM-DD
+
+category:
+ - community
+ - event-fellowship
+ - travel-fellowship
+
+
+tag:
+ - community
+ - event-fellowship
+ - travel-fellowship
+
+title: Call for the second 2026 round of the OBF Event Fellowship & overview of the first round of 2026.
+url: /2026/06/24/event-fellowship-2026-2/
+---
+
+---
+The call for applications for round 2 of the[ OBF Event Fellowship](https://www.open-bio.org/event-awards/) for 2026 is now open. The deadline for this round is 1 August 2026. You can submit your application through[ this Google Form](https://forms.gle/D31zSs558aRwj2ig9). We have provided a Word template to help you draft the application locally before filling out the form --[  make a copy of this template](https://docs.google.com/document/d/11Uiw3pVWHPhv-5_Zbnkd9EqS2J3dXWm_xqt3n6V2m4Y/edit?usp=sharing).
+
+
+The OBF Event Fellowship program aims to increase diverse participation at events that promote open-source bioinformatics and/or open science. We invite applications from candidates seeking financial support to attend relevant scientific events between September 2026 to August 2027. These events include conferences, workshops, code fests, hackathons, training courses, collaborative sprints, informal meet-ups or other skill-building and networking events. For more details, please read our [OBF Event Fellowship policy document](https://github.com/OBF/obf-docs/blob/master/Travel_fellowships.md).
+
+![David Kiragu at the 2025 AIBBC conference](https://www.open-bio.org/img/2026-02-02-image-kiragu.jpg.png)
+
+The[  Open Bioinformatics Foundation (OBF) Event Fellowship program](https://www.open-bio.org/event-awards/) is now in its 9th year. Since 2023, we have had three application rounds per year with the following deadlines: 1 April, 1 August, and 1 December.
+
+Looking back at the first round of 2026, we received 40 applications, and six applicants  were selected to support their participation in various events.
+
+1.  Francesco Maria Antonio Micocci: BITS 2026 & BioHackathon 2026, 26-29 May 2026
+
+2.  Aditya Karna: Bioinformatics Open Source Conference (BOSC 2026), July 14-15, 2026
+
+3.  Lee Jia Wei: Bioinformatics Open Source Conference (BOSC 2026), July 14-15, 2026
+
+4.  Anastasia Bratulin: 34th Conference on Intelligent Systems for Molecular Biology, July 12-16, 2026
+
+5.  Jeremy Fan: Bioinformatics Open Source Conference (BOSC 2026), July 14-15, 2026
+
+6.  Neha Arora: Bioinformatics Open Source Conference (BOSC 2026), July 14-15, 2026
+
+Congratulations to all of our awardees!  We are delighted to help support their participation in open-source-related events with OBF Event Fellowships, and we wish them all the best for their future work.
+
+**Please share this post and [apply for the fellowship](https://www.open-bio.org/event-awards/) before 1 August 2026.**


### PR DESCRIPTION
Announce the call for applications for the second round of the OBF Event Fellowship for 2026 and provide an overview of the first round's awardees.