### PR TITLE
Fix CoFest links to be year specific

### DIFF
--- a/content/page/bosc-2019.md
+++ b/content/page/bosc-2019.md
@@ -25,7 +25,7 @@ BOSC is organized by the [Open Bioinformatics Foundation (OBF)](/wiki/Main_Page
 
 Since its inception in 2000, BOSC has provided a forum for developers and users to interact and share research results and ideas in open source bioinformatics. BOSC’s broad spectrum of topics includes practical techniques for solving bioinformatics problems; software development practices; standards and ontologies; approaches that promote open science and sharing of data, results and software; and ways to grow open source communities while promoting diversity within them.
 
-BOSC is usually preceded or followed by what we now call [CollaborationFest (CoFest](/events/bosc/collaborationfest/) for short), a two-day community development session. This is an opportunity for anyone interested in open science, biology and programming to meet, talk and work collaboratively. All are welcome to attend CoFest 2019 (whether or not you attend BOSC)!
+BOSC is usually preceded or followed by what we now call [CollaborationFest (CoFest for short)](/events/bosc-2019/bosc-2019-collaborationfest/), a two-day community development session. This is an opportunity for anyone interested in open science, biology and programming to meet, talk and work collaboratively. All are welcome to attend CoFest 2019 (whether or not you attend BOSC)!
 
 [More about BOSC...](/events/bosc/about/)
 

--- a/content/page/bosc-2020-online.md
+++ b/content/page/bosc-2020-online.md
@@ -30,7 +30,7 @@ The Bioinformatics Open Source Conference (BOSC) has been [held annually since 2
 - July 16 (July 17 in eastern hemisphere): [pre-BCC open house](/2020/07/08/bcc2020-pre-conference-open-house/) for registered attendees
 - July 17-18 (July 18-19 in eastern hemisphere): BCC2020 optional [training sessions](https://bcc2020.sched.com/overview/subject/Training)
 - **July 19-21 (July 20-22 in eastern hemisphere): [BOSC 2020](/events/bosc/schedule/)**, part of [BCC2020](https://bcc2020.github.io/) (online)
-- July 22-23 and 24-25: [CoFest](/events/bosc/collaborationfest/) and CoFest Encore
+- July 22-23 and 24-25: [CoFest](/events/bosc-2020/bosc-2020-collaborationfest/) and CoFest Encore
 
 ## Session Topics
 

--- a/content/page/bosc-2020-online.md
+++ b/content/page/bosc-2020-online.md
@@ -52,7 +52,7 @@ BOSC is organized by the [Open Bioinformatics Foundation (OBF)](/wiki/Main_Page
 
 Since its inception in 2000, BOSC has provided a forum for developers and users to interact and share research results and ideas in open source bioinformatics. BOSC’s broad spectrum of topics includes practical techniques for solving bioinformatics problems; software development practices; standards and ontologies; approaches that promote open science and sharing of data, results and software; and ways to grow open source communities while promoting diversity within them.
 
-BOSC is usually preceded or followed by what we now call [CollaborationFest (CoFest](/events/bosc/collaborationfest/) for short), a two-day community development session. This is an opportunity for anyone interested in open science, biology and programming to meet, talk and work collaboratively. All are welcome to attend CoFest, whether or not you attend BOSC!
+BOSC is usually preceded or followed by what we now call [CollaborationFest (CoFest for short)](/events/bosc-2020/bosc-2020-collaborationfest/), a two-day community development session. This is an opportunity for anyone interested in open science, biology and programming to meet, talk and work collaboratively. All are welcome to attend CoFest, whether or not you attend BOSC!
 
 [More about BOSC...](/events/bosc/about/)
 

--- a/content/page/bosc-2021.md
+++ b/content/page/bosc-2021.md
@@ -78,7 +78,7 @@ BOSC is organized by the [Open Bioinformatics Foundation (OBF)](/wiki/Main_Page)
 
 Since its inception in 2000, BOSC has provided a forum for developers and users to interact and share research results and ideas in open source bioinformatics. BOSC’s broad spectrum of topics includes practical techniques for solving bioinformatics problems; software development practices; standards and ontologies; approaches that promote open science and sharing of data, results and software; and ways to grow open source communities while promoting diversity within them.
 
-BOSC is usually preceded or followed by what we now call [CollaborationFest (CoFest](/events/bosc/collaborationfest/) for short), a two-day community development session. This is an opportunity for anyone interested in open science, biology and programming to meet, talk and work collaboratively. All are welcome to attend CoFest, whether or not you attend BOSC!
+BOSC is usually preceded or followed by what we now call [CollaborationFest (CoFest for short)](events/bosc-2021/collaborationfest/)), a two-day community development session. This is an opportunity for anyone interested in open science, biology and programming to meet, talk and work collaboratively. All are welcome to attend CoFest, whether or not you attend BOSC!
 
 [More about BOSC...](/events/bosc/about/)
 

--- a/content/page/bosc-2022-1.md
+++ b/content/page/bosc-2022-1.md
@@ -81,7 +81,7 @@ BOSC is organized by the [Open Bioinformatics Foundation (OBF)](/wiki/Main_Page)
 
 Since its inception in 2000, BOSC has provided a forum for developers and users to interact and share research results and ideas in open source bioinformatics. BOSC’s broad spectrum of topics includes practical techniques for solving bioinformatics problems; software development practices; standards and ontologies; approaches that promote open science and sharing of data, results and software; and ways to grow open source communities while promoting diversity within them.
 
-BOSC is usually preceded or followed by what we now call [CollaborationFest (CoFest](/events/bosc/collaborationfest/) for short), a two-day community development session. This is an opportunity for anyone interested in open science, biology and programming to meet, talk and work collaboratively. All are welcome to attend CoFest, whether or not you attend BOSC!
+BOSC is usually preceded or followed by what we now call [CollaborationFest (CoFest for short)](/events/bosc-2022/obf-bosc-collaborationfest/), a two-day community development session. This is an opportunity for anyone interested in open science, biology and programming to meet, talk and work collaboratively. All are welcome to attend CoFest, whether or not you attend BOSC!
 
 [More about BOSC...](/events/bosc/about/)
 

--- a/content/page/bosc-2022.md
+++ b/content/page/bosc-2022.md
@@ -82,7 +82,7 @@ BOSC is organized by the [Open Bioinformatics Foundation (OBF)](/wiki/Main_Page)
 
 Since its inception in 2000, BOSC has provided a forum for developers and users to interact and share research results and ideas in open source bioinformatics. BOSC’s broad spectrum of topics includes practical techniques for solving bioinformatics problems; software development practices; standards and ontologies; approaches that promote open science and sharing of data, results and software; and ways to grow open source communities while promoting diversity within them.
 
-BOSC is usually preceded or followed by what we now call [CollaborationFest (CoFest](/events/bosc/collaborationfest/) for short), a two-day community development session. This is an opportunity for anyone interested in open science, biology and programming to meet, talk and work collaboratively. All are welcome to attend CoFest, whether or not you attend BOSC!
+BOSC is usually preceded or followed by what we now call [CollaborationFest (CoFest for short)](/events/bosc-2022/obf-bosc-collaborationfest/), a two-day community development session. This is an opportunity for anyone interested in open science, biology and programming to meet, talk and work collaboratively. All are welcome to attend CoFest, whether or not you attend BOSC!
 
 [More about BOSC...](/events/bosc/about/)
 

--- a/content/page/bosc-2023.md
+++ b/content/page/bosc-2023.md
@@ -72,7 +72,7 @@ BOSC is organized by the [Open Bioinformatics Foundation (OBF)](/wiki/Main_Page)
 
 Since its inception in 2000, BOSC has provided a forum for developers and users to interact and share research results and ideas in open source bioinformatics. BOSC’s broad spectrum of topics includes practical techniques for solving bioinformatics problems; software development practices; standards and ontologies; approaches that promote open science and sharing of data, results and software; and ways to grow open source communities while promoting diversity within them.
 
-BOSC is usually preceded or followed by what we now call [CollaborationFest (CoFest](/events/bosc-2023/obf-bosc-collaborationfest-2023/) for short), a two-day community development session. This is an opportunity for anyone interested in open science, biology and programming to meet, talk and work collaboratively. All are welcome to attend CoFest, whether or not you attend BOSC!
+BOSC is usually preceded or followed by what we now call [CollaborationFest (CoFest for short)](/events/bosc-2023/obf-bosc-collaborationfest-2023/), a two-day community development session. This is an opportunity for anyone interested in open science, biology and programming to meet, talk and work collaboratively. All are welcome to attend CoFest, whether or not you attend BOSC!
 
 [More about BOSC...](/events/bosc/about/)
 

--- a/content/page/bosc-2024.md
+++ b/content/page/bosc-2024.md
@@ -112,7 +112,7 @@ The Bioinformatics Open Source Conference (BOSC) has been [held annually since 2
 
 Since its inception, BOSC has provided a forum for developers and users to interact and share research results and ideas in open source bioinformatics. BOSC’s broad spectrum of topics includes practical techniques for solving bioinformatics problems; software development practices; standards and ontologies; approaches that promote open science and sharing of data, results and software; and ways to grow open source communities while promoting diversity within them.
 
-BOSC is usually preceded or followed by what we now call [CollaborationFest](/events/bosc-2024/obf-bosc-collaborationfest-2024/) ( [CoFest](/events/bosc-2024/obf-bosc-collaborationfest-2024/) for short), a two-day community development session. This is an opportunity for anyone interested in open science, biology and programming to meet, talk and work collaboratively. All are welcome to attend CoFest, whether or not you attend BOSC!
+BOSC is usually preceded or followed by what we now call [CollaborationFest (CoFest for short)](/events/bosc-2024/obf-bosc-collaborationfest-2024/), a two-day community development session. This is an opportunity for anyone interested in open science, biology and programming to meet, talk and work collaboratively. All are welcome to attend CoFest, whether or not you attend BOSC!
 
 [More about BOSC...](/events/bosc/about/)
 

--- a/content/page/bosc-2025.md
+++ b/content/page/bosc-2025.md
@@ -145,7 +145,7 @@ The Bioinformatics Open Source Conference (BOSC) has been [held annually since 2
 Since its inception, BOSC has provided a forum for developers and users to interact and share research results and ideas in open source bioinformatics. BOSC’s broad spectrum of topics includes practical techniques for solving bioinformatics problems; software development practices; standards and ontologies; approaches that promote open science and sharing of data, results and software; and ways to grow and sustain open source communities.
 
 BOSC is usually preceded or followed by
-[CollaborationFest](/events/bosc/collaborationfest/)
+[CollaborationFest](/events/bosc-2025/ismb-collaborationfest-2025/)
 (CoFest for short), a two-day collaborative work session. This is an
 opportunity for anyone interested in open science, biology and
 programming to meet, talk and work collaboratively. In 2025,

--- a/content/page/bosc-2026.md
+++ b/content/page/bosc-2026.md
@@ -72,7 +72,7 @@ Science for the People: Open science to engage and build trust with communities
 - **May 7: Late poster submission deadline**
 - July 12-16: [ISMB 2026](https://www.iscb.org/ismb2026/home) (Washington, DC and online)
 - **July 14-15:** **BOSC 2026** (part of ISMB 2026)
-- July 17-18: [CollaborationFest](https://www.open-bio.org/events/bosc-2026/collaborationfest/) - free (registration required) post-BOSC collaborative work event. Central Washington DC location.
+- July 17-18: [CollaborationFest](/events/bosc-2026/collaborationfest/) - free (registration required) post-BOSC collaborative work event. Central Washington DC location.
 
 {{< column >}}
 ![Three people at CoFest 2025](/img/2025/bosc2025-img/CoFest%20-%203%20people%20working%20at%20table.jpeg)
@@ -197,8 +197,7 @@ BOSC 2025 included two days of [keynote talks](/events/bosc-2025/bosc-2025-keyno
 
 ![BOSC 2025 organizing committee](/img/2025/bosc2025-img/Carlo%20Moni%20Deepak%20Nomi%20-%20CoFest%20table.jpeg)
 
-BOSC will be followed on July 17-18 by a [CollaborationFest](/events/bosc/collaborationfest/)
-(CoFest for short), a two-day collaborative work session. This is an opportunity for anyone interested in open science, biology or programming to meet, talk and work collaboratively.
+BOSC will be followed on July 17-18 by a [CollaborationFest (CoFest for short)](/events/bosc-2026/collaborationfest/), a two-day collaborative work session. This is an opportunity for anyone interested in open science, biology or programming to meet, talk and work collaboratively.
 In 2025, CollaborationFest was part of ISMB/ECCB.
 
 <a href="/events/bosc/about" class="btn btn-lg btn-primary">More about BOSC</a>

--- a/content/page/bosc-2026.md
+++ b/content/page/bosc-2026.md
@@ -197,7 +197,7 @@ BOSC 2025 included two days of [keynote talks](/events/bosc-2025/bosc-2025-keyno
 
 ![BOSC 2025 organizing committee](/img/2025/bosc2025-img/Carlo%20Moni%20Deepak%20Nomi%20-%20CoFest%20table.jpeg)
 
-BOSC will be followed on July 17-18 by a [CollaborationFest (CoFest for short)](/events/bosc-2026/collaborationfest/), a two-day collaborative work session. This is an opportunity for anyone interested in open science, biology or programming to meet, talk and work collaboratively.
+BOSC 2026 was followed on July 17-18 by a [CollaborationFest (CoFest for short)](/events/bosc-2026/collaborationfest/), a two-day collaborative work session. CoFests provide an opportunity for anyone interested in open science, biology or programming to meet, talk and work collaboratively.
 In 2025, CollaborationFest was part of ISMB/ECCB.
 
 <a href="/events/bosc/about" class="btn btn-lg btn-primary">More about BOSC</a>


### PR DESCRIPTION
Also fixes something odd in the link placement with the brackets, perhaps a minor glitch in the WordPress to Markdown migration.